### PR TITLE
ci(e2e): fail loud when wait-on times out, capture serve diagnostics

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -111,9 +111,38 @@ jobs:
 
       - name: Start server
         run: |
-          npx serve out -l 3000 &
-          sleep 5
-          npx wait-on http://localhost:3000 --timeout 60000
+          set -euo pipefail
+          npx serve out -l 3000 > serve.log 2>&1 &
+          SERVE_PID=$!
+          echo "serve started, PID=$SERVE_PID"
+
+          # Brief grace period for the child to spawn; wait-on does the real polling.
+          sleep 2
+
+          # Verify serve didn't already exit (port in use, missing out/, etc.).
+          if ! kill -0 "$SERVE_PID" 2>/dev/null; then
+            echo "::error::serve exited immediately after launch"
+            echo "--- serve.log ---"
+            cat serve.log || true
+            exit 1
+          fi
+
+          # Explicit exit-code propagation. Don't rely on -e interacting cleanly
+          # with backgrounded jobs.
+          if ! npx wait-on http://localhost:3000 --timeout 60000 --verbose; then
+            echo "::error::wait-on timed out — serve never bound to port 3000 within 60s"
+            echo "--- serve.log ---"
+            cat serve.log || true
+            echo "--- listening sockets ---"
+            ss -tlnp 2>/dev/null || netstat -tlnp 2>/dev/null || true
+            echo "--- serve process state ---"
+            ps -fp "$SERVE_PID" 2>/dev/null || echo "serve process $SERVE_PID is gone"
+            echo "--- direct curl attempt ---"
+            curl -v --max-time 5 http://localhost:3000/ 2>&1 || true
+            exit 1
+          fi
+
+          echo "serve is responding on http://localhost:3000"
 
       - name: Run smoke tests (sign-up only - auth tests run after auth-setup)
         run: |
@@ -183,9 +212,38 @@ jobs:
 
       - name: Start server
         run: |
-          npx serve out -l 3000 &
-          sleep 5
-          npx wait-on http://localhost:3000 --timeout 60000
+          set -euo pipefail
+          npx serve out -l 3000 > serve.log 2>&1 &
+          SERVE_PID=$!
+          echo "serve started, PID=$SERVE_PID"
+
+          # Brief grace period for the child to spawn; wait-on does the real polling.
+          sleep 2
+
+          # Verify serve didn't already exit (port in use, missing out/, etc.).
+          if ! kill -0 "$SERVE_PID" 2>/dev/null; then
+            echo "::error::serve exited immediately after launch"
+            echo "--- serve.log ---"
+            cat serve.log || true
+            exit 1
+          fi
+
+          # Explicit exit-code propagation. Don't rely on -e interacting cleanly
+          # with backgrounded jobs.
+          if ! npx wait-on http://localhost:3000 --timeout 60000 --verbose; then
+            echo "::error::wait-on timed out — serve never bound to port 3000 within 60s"
+            echo "--- serve.log ---"
+            cat serve.log || true
+            echo "--- listening sockets ---"
+            ss -tlnp 2>/dev/null || netstat -tlnp 2>/dev/null || true
+            echo "--- serve process state ---"
+            ps -fp "$SERVE_PID" 2>/dev/null || echo "serve process $SERVE_PID is gone"
+            echo "--- direct curl attempt ---"
+            curl -v --max-time 5 http://localhost:3000/ 2>&1 || true
+            exit 1
+          fi
+
+          echo "serve is responding on http://localhost:3000"
 
       - name: Run rate-limiting tests (ordered)
         run: pnpm test:e2e --project=rate-limiting --project=brute-force --project=signup --reporter=list --trace=on-first-retry
@@ -245,9 +303,38 @@ jobs:
 
       - name: Start server
         run: |
-          npx serve out -l 3000 &
-          sleep 5
-          npx wait-on http://localhost:3000 --timeout 60000
+          set -euo pipefail
+          npx serve out -l 3000 > serve.log 2>&1 &
+          SERVE_PID=$!
+          echo "serve started, PID=$SERVE_PID"
+
+          # Brief grace period for the child to spawn; wait-on does the real polling.
+          sleep 2
+
+          # Verify serve didn't already exit (port in use, missing out/, etc.).
+          if ! kill -0 "$SERVE_PID" 2>/dev/null; then
+            echo "::error::serve exited immediately after launch"
+            echo "--- serve.log ---"
+            cat serve.log || true
+            exit 1
+          fi
+
+          # Explicit exit-code propagation. Don't rely on -e interacting cleanly
+          # with backgrounded jobs.
+          if ! npx wait-on http://localhost:3000 --timeout 60000 --verbose; then
+            echo "::error::wait-on timed out — serve never bound to port 3000 within 60s"
+            echo "--- serve.log ---"
+            cat serve.log || true
+            echo "--- listening sockets ---"
+            ss -tlnp 2>/dev/null || netstat -tlnp 2>/dev/null || true
+            echo "--- serve process state ---"
+            ps -fp "$SERVE_PID" 2>/dev/null || echo "serve process $SERVE_PID is gone"
+            echo "--- direct curl attempt ---"
+            curl -v --max-time 5 http://localhost:3000/ 2>&1 || true
+            exit 1
+          fi
+
+          echo "serve is responding on http://localhost:3000"
 
       - name: Run auth setup
         run: pnpm exec playwright test --project=setup --reporter=list --timeout=180000
@@ -352,9 +439,38 @@ jobs:
 
       - name: Start server
         run: |
-          npx serve out -l 3000 &
-          sleep 5
-          npx wait-on http://localhost:3000 --timeout 60000
+          set -euo pipefail
+          npx serve out -l 3000 > serve.log 2>&1 &
+          SERVE_PID=$!
+          echo "serve started, PID=$SERVE_PID"
+
+          # Brief grace period for the child to spawn; wait-on does the real polling.
+          sleep 2
+
+          # Verify serve didn't already exit (port in use, missing out/, etc.).
+          if ! kill -0 "$SERVE_PID" 2>/dev/null; then
+            echo "::error::serve exited immediately after launch"
+            echo "--- serve.log ---"
+            cat serve.log || true
+            exit 1
+          fi
+
+          # Explicit exit-code propagation. Don't rely on -e interacting cleanly
+          # with backgrounded jobs.
+          if ! npx wait-on http://localhost:3000 --timeout 60000 --verbose; then
+            echo "::error::wait-on timed out — serve never bound to port 3000 within 60s"
+            echo "--- serve.log ---"
+            cat serve.log || true
+            echo "--- listening sockets ---"
+            ss -tlnp 2>/dev/null || netstat -tlnp 2>/dev/null || true
+            echo "--- serve process state ---"
+            ps -fp "$SERVE_PID" 2>/dev/null || echo "serve process $SERVE_PID is gone"
+            echo "--- direct curl attempt ---"
+            curl -v --max-time 5 http://localhost:3000/ 2>&1 || true
+            exit 1
+          fi
+
+          echo "serve is responding on http://localhost:3000"
         env:
           CI: true
 
@@ -482,9 +598,38 @@ jobs:
           path: tests/e2e/fixtures/
       - name: Start server
         run: |
-          npx serve out -l 3000 &
-          sleep 5
-          npx wait-on http://localhost:3000 --timeout 60000
+          set -euo pipefail
+          npx serve out -l 3000 > serve.log 2>&1 &
+          SERVE_PID=$!
+          echo "serve started, PID=$SERVE_PID"
+
+          # Brief grace period for the child to spawn; wait-on does the real polling.
+          sleep 2
+
+          # Verify serve didn't already exit (port in use, missing out/, etc.).
+          if ! kill -0 "$SERVE_PID" 2>/dev/null; then
+            echo "::error::serve exited immediately after launch"
+            echo "--- serve.log ---"
+            cat serve.log || true
+            exit 1
+          fi
+
+          # Explicit exit-code propagation. Don't rely on -e interacting cleanly
+          # with backgrounded jobs.
+          if ! npx wait-on http://localhost:3000 --timeout 60000 --verbose; then
+            echo "::error::wait-on timed out — serve never bound to port 3000 within 60s"
+            echo "--- serve.log ---"
+            cat serve.log || true
+            echo "--- listening sockets ---"
+            ss -tlnp 2>/dev/null || netstat -tlnp 2>/dev/null || true
+            echo "--- serve process state ---"
+            ps -fp "$SERVE_PID" 2>/dev/null || echo "serve process $SERVE_PID is gone"
+            echo "--- direct curl attempt ---"
+            curl -v --max-time 5 http://localhost:3000/ 2>&1 || true
+            exit 1
+          fi
+
+          echo "serve is responding on http://localhost:3000"
         env:
           CI: true
       - name: Prime Supabase connection pool
@@ -596,9 +741,38 @@ jobs:
           path: tests/e2e/fixtures/
       - name: Start server
         run: |
-          npx serve out -l 3000 &
-          sleep 5
-          npx wait-on http://localhost:3000 --timeout 60000
+          set -euo pipefail
+          npx serve out -l 3000 > serve.log 2>&1 &
+          SERVE_PID=$!
+          echo "serve started, PID=$SERVE_PID"
+
+          # Brief grace period for the child to spawn; wait-on does the real polling.
+          sleep 2
+
+          # Verify serve didn't already exit (port in use, missing out/, etc.).
+          if ! kill -0 "$SERVE_PID" 2>/dev/null; then
+            echo "::error::serve exited immediately after launch"
+            echo "--- serve.log ---"
+            cat serve.log || true
+            exit 1
+          fi
+
+          # Explicit exit-code propagation. Don't rely on -e interacting cleanly
+          # with backgrounded jobs.
+          if ! npx wait-on http://localhost:3000 --timeout 60000 --verbose; then
+            echo "::error::wait-on timed out — serve never bound to port 3000 within 60s"
+            echo "--- serve.log ---"
+            cat serve.log || true
+            echo "--- listening sockets ---"
+            ss -tlnp 2>/dev/null || netstat -tlnp 2>/dev/null || true
+            echo "--- serve process state ---"
+            ps -fp "$SERVE_PID" 2>/dev/null || echo "serve process $SERVE_PID is gone"
+            echo "--- direct curl attempt ---"
+            curl -v --max-time 5 http://localhost:3000/ 2>&1 || true
+            exit 1
+          fi
+
+          echo "serve is responding on http://localhost:3000"
         env:
           CI: true
       - name: Prime Supabase connection pool


### PR DESCRIPTION
## Summary

CI run [24970006226](https://github.com/TortoiseWolfe/ScriptHammer/actions/runs/24970006226) on commit \`00edd23\` had **14/26 jobs fail**. All 7 firefox shards and all 6 webkit-gen shards failed with \`NS_ERROR_CONNECTION_REFUSED\` to \`http://localhost:3000/account\` in their first \`beforeEach\`. The static server (\`npx serve out -l 3000\`) wasn't responding when Playwright tried to connect, but the workflow proceeded to run tests anyway — producing 50 minutes of cascade ECONNREFUSED per shard with no actionable signal.

The bug is in the workflow: \`Start server\` ran \`npx serve ... &; sleep 5; npx wait-on ... --timeout 60000\`, and wait-on's failure was not reliably propagating as a step error (likely \`-e\` interacting badly with the backgrounded job).

## Fix

Replace all 6 identical \`Start server\` blocks with a defensive version that:

1. Captures serve's PID and tees output to \`serve.log\`
2. Verifies serve didn't exit immediately (port in use, missing \`out/\`, etc.)
3. Explicitly checks wait-on's exit code via \`if ! ... ; then ...\`
4. On failure: dumps \`serve.log\`, listening sockets (\`ss\`/\`netstat\`), serve process state (\`ps\`), and a direct \`curl\` probe — then \`exit 1\`
5. On success: prints \`serve is responding on http://localhost:3000\` for grep-friendly logs

Affected jobs (one block each): \`smoke\`, \`rate-limiting\`, \`auth-setup\`, \`e2e\`, \`e2e-firefox\`, \`e2e-webkit\`. All 6 jobs preserve their existing \`env: CI: true\` blocks (where present on \`e2e\`, \`e2e-firefox\`, \`e2e-webkit\`).

## What this gives us

After merge, the *next* failing run produces clear diagnostics at the moment of failure, instead of cascading 100s of test failures downstream. Total wall time on a serve-bind failure goes from ~50 minutes per shard to ~90 seconds. That signal will tell us *why* serve isn't binding (timeout too short? serve crash? port collision?) — currently the cascade noise drowns it out.

## What this doesn't do

- No timeout bump. We have no evidence yet that 60s is too short — bump speculatively only after diagnostics confirm. Follow-up plan, not this PR.
- No source-code changes. Workflow only.
- Doesn't address [#50](https://github.com/TortoiseWolfe/ScriptHammer/issues/50)/[#57](https://github.com/TortoiseWolfe/ScriptHammer/issues/57) (cross-shard messaging test-user collision) — different root cause, different fix.

## Test plan

- [x] YAML parses cleanly (\`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2e.yml'))"\`); 8 jobs intact.
- [x] All 6 \`Start server\` blocks contain \`serve started, PID=\` and \`wait-on timed out\` strings (\`grep -c\` returns 6).
- [x] The 3 \`env: CI: true\` blocks (e2e/firefox/webkit jobs) are still attached.
- [ ] Real CI verification on this PR's run: smoke, rate-limiting, auth-setup, and chromium-gen jobs should produce \`serve is responding on http://localhost:3000\` log line. Firefox/webkit jobs may either pass or fail loudly (≤90s) with diagnostics; either is the signal we want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)