### PR TITLE
fix(docker): pre-create node_modules with node ownership for named volume

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -96,6 +96,17 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
 COPY --from=deps /app/node_modules ./node_modules
 RUN npx playwright install chromium firefox webkit
 
+# Pre-create directories that mount as named volumes so they inherit
+# node:node ownership rather than Docker's default root:root. Without
+# this, `docker volume rm scripthammer_node_modules && docker compose up`
+# (or any fresh-clone first start) leaves the mountpoint root-owned,
+# causing EACCES when pnpm runs as node and tries to recreate .bin.
+# Mirrors the ce0e64d fix that originally landed for .next.
+# See: docs/interoffice/audits/2026-05-02-supabase-banner-audit.md (#69)
+RUN chown -R node:node /app/node_modules \
+    && mkdir -p /app/.next \
+    && chown -R node:node /app/.next
+
 # Entrypoint needs root for chmod, copy before USER switch
 COPY docker/docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh


### PR DESCRIPTION
## Summary

- Pre-creates `/app/node_modules` and `/app/.next` with `node:node` ownership in the Dockerfile `dev` stage so Docker named volumes inherit node ownership on first mount, fixing `EACCES` on container start when pnpm runs as `node` and tries to recreate `.bin`.
- Mirrors the `ce0e64d` pattern that originally landed for `.next`. The `.next` pre-create had been removed during `7bdb86a`'s refactor; this commit restores it alongside the new `node_modules` treatment.

## Problem

Latent bug. As long as the `scripthammer_node_modules` volume is reused across `up/down` cycles, ownership stays correct (set once on first install). It bites only on volume reset (`docker volume rm scripthammer_node_modules`, `docker compose down -v`, or first-startup of a fresh-clone fork). Symptom:

```
EACCES: permission denied, rmdir '/app/node_modules/.bin'
```

The container enters a restart loop on exit code 243.

## Why this matters for the fork roadmap

Phase 1a (GrimGlow browser fork), Phase 2 (RN ScriptHammer extraction), and Phase 3 (KDG-stack template) all start from a `gh repo create` clone followed by a fresh `docker compose up` — i.e., always a brand-new volume. Every fresh fork will hit this bug on first startup. Fix once at the source.

## Test plan

Verified locally:

- [x] `docker compose down && docker volume rm scripthammer_node_modules scripthammer_next_cache && docker compose build && docker compose up -d`
- [x] Container reaches healthy state (`Up`, no `Restarting (243)`)
- [x] No `EACCES` errors in `docker compose logs scripthammer`
- [x] `docker run --rm -v scripthammer_node_modules:/v alpine ls -ld /v` reports `1000:1000` (was `root:root` before fix)
- [x] Husky pre-commit hooks ran clean (gitleaks, lint-staged)
- [x] Pre-push CI checks all passed

## Refs

Closes #69
- Reference fix: `ce0e64d` (`.next` named volume)
- Removed-by: `7bdb86a` (refactor that dropped the `.next` pre-create alongside the slow `chown -R`)
- Bret Fisher named-volume guidance: `~/repos/TranScripts/Docker/Docker_Edited/nodejs_rocks_in_docker_dockercon2023.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)