### PR TITLE
chore(gitignore): ignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ public/manifest.json
 
 # Claude Code local settings (user-specific permissions)
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # Local Specify development tools (keep outputs, ignore scripts/templates)
 .specify/scripts/


### PR DESCRIPTION
## Summary

One-line `.gitignore` addition. Claude Code's `.claude/scheduled_tasks.lock` is transient state regenerated each session — never useful to version, but currently surfaces in every `git status` as an untracked file.

Mirrors the same pattern added to GrimGlow_planning (`e25cef7`) and grimglow-unity (already in place from initial bootstrap) so `git status` stays quiet across the GrimGlow IP family.

## Test plan

- [x] gitleaks clean
- [x] No staged files matched lint-staged tasks (just `.gitignore`)

## Refs

Sibling commit in GrimGlow_planning: https://github.com/TortoiseWolfe/GrimGlow_planning/commit/e25cef7

🤖 Generated with [Claude Code](https://claude.com/claude-code)