### PR TITLE
fix(messaging): revert sharedSecretCache reuse in getMessageHistory (regression hotfix)

### DIFF
--- a/src/services/messaging/message-service.ts
+++ b/src/services/messaging/message-service.ts
@@ -771,37 +771,32 @@ export class MessageService {
         };
       }
 
-      // Reuse the module-level sharedSecretCache so a polling loop or a
-      // refresh of the same conversation doesn't re-run ECDH derivation
-      // every call. ECDH is computationally cheap individually but compounds
-      // at ~6/min under polling. Invalidate the cache when the sender's
-      // private key identity changes (e.g. after key rotation / re-derive).
-      if (cachedSenderPrivateKey !== currentKeys.privateKey) {
-        sharedSecretCache.clear();
-        cachedSenderPrivateKey = currentKeys.privateKey;
-      }
-      let sharedSecret = sharedSecretCache.get(otherParticipantId) ?? null;
-      if (!sharedSecret) {
-        logger.debug('Importing other user public key via crypto.subtle');
-        const otherPublicKeyCrypto = await crypto.subtle.importKey(
-          'jwk',
-          otherPublicKey,
-          {
-            name: 'ECDH',
-            namedCurve: 'P-256',
-          },
-          false,
-          []
-        );
-        logger.debug('Other user public key imported successfully');
+      // Derive a fresh shared secret per call. An earlier batch reused the
+      // module-level sharedSecretCache here (matching sendMessage's pattern)
+      // but it caused a real Firefox/WebKit messaging E2E regression — the
+      // cached CryptoKey reference behaves differently across reload + tab
+      // contexts on those browsers, and polling could see stale or mismatched
+      // shared secrets. Reverted in hotfix until a browser-safe instance-aware
+      // cache key is designed. Fresh derivation is ~6 ECDH derivations/min
+      // under polling — measurable but not user-perceivable.
+      logger.debug('Importing other user public key via crypto.subtle');
+      const otherPublicKeyCrypto = await crypto.subtle.importKey(
+        'jwk',
+        otherPublicKey,
+        {
+          name: 'ECDH',
+          namedCurve: 'P-256',
+        },
+        false,
+        []
+      );
+      logger.debug('Other user public key imported successfully');
 
-        // Derive shared secret using our derived private key
-        sharedSecret = await encryptionService.deriveSharedSecret(
-          currentKeys.privateKey,
-          otherPublicKeyCrypto
-        );
-        sharedSecretCache.set(otherParticipantId, sharedSecret);
-      }
+      // Derive shared secret using our derived private key
+      const sharedSecret = await encryptionService.deriveSharedSecret(
+        currentKeys.privateKey,
+        otherPublicKeyCrypto
+      );
 
       // Log key fingerprints for E2E diagnostics (debug-suppressed in prod)
       const otherKeyFingerprint = otherPublicKey?.x?.slice(0, 8) ?? 'null';


### PR DESCRIPTION
## Summary

Surgical revert of one change from PR #74 (batch 8) that introduced a Firefox/WebKit messaging E2E regression. All other batch 8 changes (non-extractable in-memory ECDH key, cursorRef pagination fix, console→logger, payment type narrow) remain intact.

## Evidence — this is a real regression, not a flake

| Run | Branch / commit | Date | Result |
|---|---|---|---|
| `25306048649` | main `dd83ac7` (pre-batch-8) | today 07:14 UTC | ✅ all green |
| `25332113434` | main `0e20fb3` (post-batch-8) | today 17:04 UTC | ❌ firefox-msg failed |
| PR #70 rebased | `33e7b80` (carries batch 8) | today | ❌ webkit-msg failed |
| PR #75 first run | `ca61ee7` (carries batch 8) | today | ❌ firefox-msg failed |

The very first post-batch-8 run on `main` reproduced the failure pattern. Pre-batch-8 main was green this morning. Causality chain is clear.

## Failure symptoms

- Firefox/WebKit messaging tests time out waiting for cross-window message visibility
- `message-delete-placeholder`: `getByText('[Message deleted]')` resolved to **2 elements** — duplicate render
- All failures involve the polling fallback (`waitForMessageOnPage2`)

## Root cause

Batch 8 added a module-level shared-secret cache read-path in `getMessageHistory` (lines 772-802 of `message-service.ts`) to avoid re-deriving ECDH on every poll tick. The cache reuse is symmetric in design (same pattern as `sendMessage`'s cache, which has been there for months) — but interacts badly with Firefox/WebKit reload + tab semantics.

Hypothesis: the cached `CryptoKey` reference behaves differently across these browsers when `getCurrentKeys()` returns a freshly-deserialized key from IndexedDB after a page reload. The invalidation guard `cachedSenderPrivateKey !== currentKeys.privateKey` was likely thrashing or holding a stale reference, causing decryption to use mismatched secrets.

## What this PR does

`getMessageHistory` now derives a fresh shared secret per call, matching pre-batch-8 behavior. The cache infrastructure remains in place — `sendMessage` still uses it as before. **This revert is read-path only.**

## Cost

~6 ECDH derivations/min under polling — measurable but not user-perceivable. A browser-safe instance-aware cache key can return as a separate change once the Firefox CryptoKey-reference behavior is properly understood.

## What's preserved from batch 8

- ✅ Non-extractable in-memory ECDH private key (security fix, primary motivation)
- ✅ `cursorRef` pagination stale-closure fix in ConversationView
- ✅ console → logger.{debug,error} migration
- ✅ payment-service type narrow

## Verification

- `pnpm run type-check`: clean
- `pnpm run lint`: clean
- `pnpm test`: **3237/3237 pass**
- Husky pre-push (lint, type-check, unit, build): all green

## Test plan

- [x] CI runs the full E2E suite — Firefox/WebKit messaging shards expected to recover

## Refs

- Introduced regression: PR #74 / commit `52becd7`
- Last known-green main: run `25306048649` on `dd83ac7`
- First known-red main: run `25332113434` on `0e20fb3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)