### PR TITLE
fix(setup-banner): #24 — name env vars in copy, fix docsUrl, document auto-banner

### DIFF
--- a/docs/FORKING.md
+++ b/docs/FORKING.md
@@ -158,6 +158,8 @@ The deployment automatically detects your repository name and sets the correct b
 
 ## Supabase Setup
 
+While Supabase env vars are unset, you'll see a yellow "Setup required" banner on every page of the running app. This is intentional — it disappears automatically once `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` are populated. The banner is also dismissible via the × button if you want to focus on non-Supabase features first.
+
 ### 1. Create Supabase Project
 
 1. Go to [supabase.com](https://supabase.com) and create a new project

--- a/src/components/SetupBanner/SetupBanner.test.tsx
+++ b/src/components/SetupBanner/SetupBanner.test.tsx
@@ -61,8 +61,19 @@ describe('SetupBanner', () => {
       const link = screen.getByText('View setup guide');
       expect(link).toHaveAttribute(
         'href',
-        'https://github.com/TortoiseWolfe/ScriptHammer#supabase-setup'
+        'https://github.com/TortoiseWolfe/ScriptHammer/blob/main/docs/FORKING.md#supabase-setup'
       );
+    });
+
+    it('should name both required env vars in default message', () => {
+      // Fork users seeing the banner need to know exactly which two
+      // NEXT_PUBLIC_* vars to populate. Pin both names so a future copy
+      // refactor doesn't drop one.
+      render(<SetupBanner show={true} />);
+      expect(screen.getByText(/NEXT_PUBLIC_SUPABASE_URL/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/NEXT_PUBLIC_SUPABASE_ANON_KEY/)
+      ).toBeInTheDocument();
     });
 
     it('should render setup guide link with custom URL', () => {

--- a/src/components/SetupBanner/SetupBanner.tsx
+++ b/src/components/SetupBanner/SetupBanner.tsx
@@ -20,8 +20,8 @@ const STORAGE_KEY = 'supabase_setup_banner_dismissed';
  * Auto-detects Supabase configuration status when show prop is not provided.
  */
 export function SetupBanner({
-  message = 'Supabase is not configured. Some features may be unavailable.',
-  docsUrl = 'https://github.com/TortoiseWolfe/ScriptHammer#supabase-setup',
+  message = 'Supabase is not configured: set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY in your .env file.',
+  docsUrl = 'https://github.com/TortoiseWolfe/ScriptHammer/blob/main/docs/FORKING.md#supabase-setup',
   show,
 }: SetupBannerProps) {
   const [isDismissed, setIsDismissed] = useState(true); // Start hidden to avoid flash


### PR DESCRIPTION
## Summary

Three small clarity gaps in the SetupBanner that fork users hit on first run with empty Supabase config. The component itself already shipped (5-file pattern, consent-aware, auto-detects via \`isSupabaseConfigured()\`); this PR closes the remaining copy/docs gaps identified by the 2026-05-02 audit.

## What changed

### 1. Default message names the env vars
**Was:** \`Supabase is not configured. Some features may be unavailable.\` — fork users couldn't tell which two \`NEXT_PUBLIC_*\` vars to populate.
**Now:** \`Supabase is not configured: set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY in your .env file.\`

### 2. Default docsUrl points at the actual setup guide
**Was:** \`github.com/.../ScriptHammer#supabase-setup\` — non-existent README anchor.
**Now:** \`github.com/.../docs/FORKING.md#supabase-setup\` — exists, canonical setup walkthrough.

### 3. \`docs/FORKING.md\` mentions the auto-banner
Added a paragraph at the top of the Supabase Setup section explaining the banner is intentional, auto-disappears once env vars are populated, and is dismissible. Fork users were arriving at FORKING.md with no indication that the yellow alert wasn't a bug.

## Tests

- Updated default-prop URL assertion to the new href
- **Added regression pin**: a new test asserts both \`NEXT_PUBLIC_SUPABASE_URL\` and \`NEXT_PUBLIC_SUPABASE_ANON_KEY\` appear in the default message, so a future copy refactor can't silently drop one

## Verification

- \`pnpm run type-check\`: clean
- \`pnpm run lint\`: clean
- \`pnpm test\`: **3248/3248 pass** (one new regression test)

## Refs

- PRP: \`docs/prp-docs/supabase-banner-clarity-prp.md\` (Option A chosen for docsUrl — direct link to FORKING.md, no README change required)
- Audit: \`docs/interoffice/audits/2026-05-02-supabase-banner-audit.md\`

## Closes

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)