### PR TITLE
fix(e2e): round 12 — handleReAuthModal retries when modal re-appears (WebKit Argon2id flake)

### DIFF
--- a/tests/e2e/utils/test-user-factory.ts
+++ b/tests/e2e/utils/test-user-factory.ts
@@ -777,19 +777,66 @@ export async function handleReAuthModal(
     return false;
   }
 
-  // Fill password and submit
-  const passwordInput = modal.locator('input[type="password"]').first();
-  await passwordInput.fill(testPassword);
+  // Fill password and submit. Allow up to 3 attempts to handle the
+  // documented WebKit-on-Linux flake: Argon2id key derivation is slow
+  // enough on webkit-msg that the ReAuthModal can briefly transition to
+  // `hidden` (Playwright's `waitFor({state:'hidden'})` resolves) and then
+  // re-appear when the underlying unlock actually fails or retries.
+  // We treat "hidden then back" as a transient failure and re-submit the
+  // password. This caught a deterministic 3/3-retry failure mode in
+  // 26105491210 webkit-msg 1/1 (PR #95 rebased run, 2026-05-19) where the
+  // failure-time screenshot showed the modal still visible despite the
+  // helper having "succeeded".
+  const MAX_ATTEMPTS = 3;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    const passwordInput = modal.locator('input[type="password"]').first();
+    await passwordInput.fill(testPassword);
 
-  const submitBtn = modal.locator('button[type="submit"]').first();
-  await submitBtn.click();
+    const submitBtn = modal.locator('button[type="submit"]').first();
+    await submitBtn.click();
 
-  // Wait for modal to close. Argon2id key derivation is CPU-intensive
-  // and under 24-shard CI load with WebCrypto thread contention can take
-  // 60+ seconds. Generous timeout prevents flaky failures.
-  await modal.waitFor({ state: 'hidden', timeout: 90000 });
-  console.log(`[handleReAuthModal] ✓ Modal closed. URL: ${page.url()}`);
-  return true;
+    // Wait for modal to close. Argon2id key derivation is CPU-intensive
+    // and under 24-shard CI load with WebCrypto thread contention can take
+    // 60+ seconds. Generous timeout prevents flaky failures.
+    try {
+      await modal.waitFor({ state: 'hidden', timeout: 90000 });
+    } catch {
+      console.log(
+        `[handleReAuthModal] ✗ Modal never hidden on attempt ${attempt}/${MAX_ATTEMPTS}.`
+      );
+      if (attempt === MAX_ATTEMPTS) return false;
+      continue;
+    }
+
+    // Verify the hidden state is SUSTAINED — poll for an extra 2 seconds
+    // to confirm the modal doesn't pop back. Under WebKit + slow Argon2id
+    // we sometimes see a brief hide transition before the dialog re-opens
+    // because the actual unlock failed.
+    const sustainedHidden = await modal
+      .waitFor({ state: 'hidden', timeout: 2000 })
+      .then(async () => {
+        // Sleep + recheck. If still hidden, we're good.
+        await new Promise<void>((resolve) => setTimeout(resolve, 2000));
+        return (await modal.count()) === 0 || !(await modal.isVisible());
+      })
+      .catch(() => false);
+
+    if (sustainedHidden) {
+      console.log(
+        `[handleReAuthModal] ✓ Modal closed (attempt ${attempt}/${MAX_ATTEMPTS}). URL: ${page.url()}`
+      );
+      return true;
+    }
+
+    console.log(
+      `[handleReAuthModal] ⚠ Modal re-appeared after attempt ${attempt}/${MAX_ATTEMPTS}; retrying...`
+    );
+  }
+
+  console.log(
+    `[handleReAuthModal] ✗ Modal persisted after ${MAX_ATTEMPTS} unlock attempts. URL: ${page.url()}`
+  );
+  return false;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Failure screenshot from PR #95 rebased run [26105491210/webkit-msg](https://github.com/TortoiseWolfe/ScriptHammer/actions/runs/26105491210) reveals the test is **stuck on the ReAuthModal**, not on a scroll bug.
- Round-10 fix (concurrency mutex) and round-11 fix (PR #97 native scroll listener) both remain correct — they applied to different surfaces.
- This is a **separate, deeper flake** in `handleReAuthModal`: Playwright's `waitFor({state:'hidden'})` resolves on a brief transition during Argon2id processing, the helper returns true, then the modal re-appears when the actual unlock fails.

## Failure evidence

Failure-time screenshot extracted from `blob-report-webkit-msg-0/extracted/resources/796501bc4e45158f1f22d5cfe0e35fb574710a9d.png`:

> Page shows "Enter Your Messaging Password" modal with `scripthammer.e2e+test-primary@gmail.com` pre-filled. No message thread, no conversation list, no scroll surface. The `[data-testid="jump-to-bottom"]` button was never going to exist.

The trace shows `Wait for selector locator('[role="dialog"]').first()` (state=hidden) succeeding, the test proceeding to viewport setup, navigation, clickFirstConversation, scroll setup, and assertion — but the failure screenshot shows the modal back. The helper trusted a brief hidden transition that didn't stick.

## Root cause

```
1. Test fills password, clicks Unlock Messages
2. ReAuthModal starts Argon2id derivation (slow on WebKit/Linux/CI)
3. Modal briefly transitions hidden during processing
4. Playwright.waitFor({state:'hidden'}) resolves on this transition
5. Helper returns true — but unlock actually fails internally
6. Modal re-opens
7. Test continues into a UI that never mounted
```

WebKit-specific because WebKit's WebCrypto thread contention on Linux runners is significantly worse than chromium/firefox.

## Fix

After `waitFor({state:'hidden'})` resolves, **verify hidden state is sustained** for ~2 seconds via a sleep+recheck. If the modal pops back, treat as transient failure and retry the password unlock up to 3 times total.

```ts
const MAX_ATTEMPTS = 3;
for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
  // ...fill + click + waitFor(hidden, 90s)...
  const sustainedHidden = await modal
    .waitFor({ state: 'hidden', timeout: 2000 })
    .then(async () => {
      await new Promise(resolve => setTimeout(resolve, 2000));
      return (await modal.count()) === 0 || !(await modal.isVisible());
    })
    .catch(() => false);
  if (sustainedHidden) return true;
  // else loop
}
return false;
```

## Why this is structural, not a band-aid

- The `waitFor` API resolves on transition events; we now confirm steady-state. Same pattern React 18+ ecosystem applies for `useTransition`-style state where intermediate values can fire listeners.
- 3 retries is bounded — no infinite loops.
- Returns `false` cleanly if all attempts fail; callers can branch.
- No timeout extensions beyond the existing 90s per attempt.
- Doesn't mask other test bugs: if the unlock genuinely fails 3x, the test gets a definitive failure (instead of a confusing downstream error like "button not found").

## Test plan

- [x] Type-check clean
- [x] Lint clean
- [ ] CI passes (this PR)
- [ ] After merge, PR #95 rebases onto new main and passes webkit-msg

## Rounds 10 / 11 / 12 — independent, all correct

| Round | Fix | Layer |
|---|---|---|
| 10 (#89) | repo-wide E2E concurrency mutex | CI serialization vs Supabase races |
| 11 (#97) | MessageThread native scroll listener | React onScroll synthetic event vs WebKit dispatch |
| 12 (this) | handleReAuthModal sustained-hidden verification | Playwright waitFor transition vs sustained DOM state |

Each addresses a distinct flake mode. Round 12 was previously masked because rounds 10 and 11 weren't fully closed yet, so other shards failed first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)