### PR TITLE
test(e2e): #109 isolated static fixture for messaging-scroll (verified)

### DIFF
--- a/tests/e2e/messaging/messaging-scroll.spec.ts
+++ b/tests/e2e/messaging/messaging-scroll.spec.ts
@@ -2,11 +2,23 @@ import { test, expect, Page } from '@playwright/test';
 import {
   dismissCookieBanner,
   handleReAuthModal,
+  seedScrollFixture,
+  deleteScrollFixture,
+  type ScrollFixture,
 } from '../utils/test-user-factory';
 
 // Test user credentials
 const TEST_USER_PASSWORD =
   process.env.TEST_USER_PRIMARY_PASSWORD || 'TestPassword123!';
+const PRIMARY_EMAIL = process.env.TEST_USER_PRIMARY_EMAIL;
+
+// Issue #109: T007-T008 needs a thread tall enough to scroll, but the shared
+// messaging conversation is deliberately kept SHORT by other specs'
+// cleanupOldMessages() calls. So this spec builds its OWN isolated, static
+// fixture — a throwaway user + private conversation with PRIMARY + a fixed 30
+// messages — that no cleanup ever touches. See seedScrollFixture().
+const SCROLL_FIXTURE_MESSAGE_COUNT = 30;
+let scrollFixture: ScrollFixture | null = null;
 
 /**
  * Wait for UI to stabilize after navigation or interaction
@@ -43,6 +55,15 @@ async function waitForUIStability(page: Page) {
 let setupSucceeded = false;
 
 test.beforeAll(async ({ browser }) => {
+  // Build the isolated, static scroll fixture (issue #109). No-ops gracefully
+  // if credentials/admin client are unavailable, preserving the skip path.
+  if (PRIMARY_EMAIL) {
+    scrollFixture = await seedScrollFixture(
+      PRIMARY_EMAIL,
+      SCROLL_FIXTURE_MESSAGE_COUNT
+    );
+  }
+
   const context = await browser.newContext({
     storageState: './tests/e2e/fixtures/storage-state-auth.json',
   });
@@ -67,6 +88,11 @@ test.beforeAll(async ({ browser }) => {
   } finally {
     await context.close();
   }
+});
+
+test.afterAll(async () => {
+  // Tear down the fixture user — cascades its conversation + messages away.
+  await deleteScrollFixture(scrollFixture);
 });
 
 // Test configuration for viewports
@@ -266,15 +292,27 @@ test.describe('Messaging Scroll - User Story 3: Jump to Bottom Button', () => {
   test('T007-T008: Jump button appears when scrolled and does not overlap input', async ({
     page,
   }) => {
-    test.skip(!setupSucceeded, 'No conversations for test user in CI');
+    // Requires the isolated, tall scroll fixture (issue #109). Skip with a
+    // CLEAR, logged reason if it couldn't be built (e.g. admin client / creds
+    // unavailable) — never a silent pass that hides zero coverage.
+    test.skip(
+      !scrollFixture,
+      'Scroll fixture unavailable (no admin client / credentials) — cannot build a scrollable thread'
+    );
+    const conversationId = scrollFixture!.conversationId;
+
     await page.setViewportSize(VIEWPORTS.desktop);
     await page.goto('about:blank').catch(() => {});
-    await page.goto('/messages', { waitUntil: 'domcontentloaded' });
+    // Open the fixture conversation DIRECTLY by id — deterministic, not
+    // dependent on conversation-list sort order.
+    await page.goto(`/messages?conversation=${conversationId}`, {
+      waitUntil: 'domcontentloaded',
+    });
     await handleReAuthModal(page, TEST_USER_PASSWORD);
 
-    await clickFirstConversation(page);
-
     const messageThread = page.locator('[data-testid="message-thread"]');
+    await expect(messageThread).toBeVisible({ timeout: 30000 });
+    await waitForUIStability(page);
 
     // Scroll up more than 500px to trigger button
     await messageThread.evaluate((el) => {
@@ -284,10 +322,8 @@ test.describe('Messaging Scroll - User Story 3: Jump to Bottom Button', () => {
 
     await waitForUIStability(page);
 
-    // Check if jump button appears
     const jumpButton = page.locator('[data-testid="jump-to-bottom"]');
 
-    // Button should appear when scrolled 500px+ from bottom
     const scrollInfo = await messageThread.evaluate((el) => ({
       scrollTop: el.scrollTop,
       scrollHeight: el.scrollHeight,
@@ -295,34 +331,43 @@ test.describe('Messaging Scroll - User Story 3: Jump to Bottom Button', () => {
       distanceFromBottom: el.scrollHeight - (el.scrollTop + el.clientHeight),
     }));
 
-    if (scrollInfo.distanceFromBottom > 500) {
-      // Wait for the parent wrapper's `data-show-scroll-button` attribute
-      // to flip to "true" before asserting button visibility. The attribute
-      // is written by MessageThread.tsx synchronously when `setShowScroll
-      // Button(true)` commits — bypassing the React-state-flush vs
-      // WebKit-event-loop race that rounds 10-13 chased through other
-      // surfaces. See round 14 for the structural fix.
-      const wrapper = page.locator('[data-show-scroll-button]').first();
-      await expect
-        .poll(
-          async () => await wrapper.getAttribute('data-show-scroll-button'),
-          { timeout: 5000, intervals: [50, 100, 200, 500] }
-        )
-        .toBe('true');
+    // The fixture seeds a fixed 30 messages, so the thread MUST be scrollable
+    // past the 500px threshold. Assert it (rather than silently skipping the
+    // button checks) — a short thread here is a real regression or a fixture
+    // failure, not a no-op.
+    expect(
+      scrollInfo.distanceFromBottom,
+      'fixture thread should be tall enough to scroll 500px+ from bottom'
+    ).toBeGreaterThan(500);
 
-      await expect(jumpButton).toBeVisible();
+    // Wait for the parent wrapper's `data-show-scroll-button` attribute
+    // to flip to "true" before asserting button visibility. The attribute
+    // is written by MessageThread.tsx synchronously when `setShowScroll
+    // Button(true)` commits — bypassing the React-state-flush vs
+    // WebKit-event-loop race that rounds 10-13 chased through other
+    // surfaces. See round 14 for the structural fix.
+    const wrapper = page.locator('[data-show-scroll-button]').first();
+    await expect
+      .poll(async () => await wrapper.getAttribute('data-show-scroll-button'), {
+        timeout: 5000,
+        intervals: [50, 100, 200, 500],
+      })
+      .toBe('true');
 
-      // Verify button doesn't overlap message input
-      const buttonBox = await jumpButton.boundingBox();
-      const messageInput = page.locator(
-        'textarea[placeholder*="Type a message"], textarea[placeholder*="message"]'
-      );
-      const inputBox = await messageInput.boundingBox();
+    await expect(jumpButton).toBeVisible();
 
-      if (buttonBox && inputBox) {
-        // Button bottom should be above input top
-        expect(buttonBox.y + buttonBox.height).toBeLessThanOrEqual(inputBox.y);
-      }
+    // Verify button doesn't overlap message input
+    const buttonBox = await jumpButton.boundingBox();
+    const messageInput = page.locator(
+      'textarea[placeholder*="Type a message"], textarea[placeholder*="message"]'
+    );
+    const inputBox = await messageInput.boundingBox();
+
+    expect(buttonBox).not.toBeNull();
+    expect(inputBox).not.toBeNull();
+    if (buttonBox && inputBox) {
+      // Button bottom should be above input top
+      expect(buttonBox.y + buttonBox.height).toBeLessThanOrEqual(inputBox.y);
     }
   });
 

--- a/tests/e2e/utils/test-user-factory.ts
+++ b/tests/e2e/utils/test-user-factory.ts
@@ -1190,6 +1190,142 @@ export async function cleanupOldMessages(
 }
 
 /**
+ * A self-contained, static message-thread fixture for the messaging-scroll
+ * test (issue #109).
+ *
+ * WHY this exists / why it doesn't just reuse the shared users:
+ * Every messaging spec calls cleanupOldMessages() in beforeAll, which does
+ * `DELETE FROM messages WHERE sender_id IN (PRIMARY, TERTIARY)`. That cleanup
+ * is deliberate — it keeps the shared conversation under 100 messages so the
+ * MessageThread virtualizer doesn't hide other specs' newly-sent messages.
+ * But messaging-scroll needs the OPPOSITE: a thread tall enough to scroll. Any
+ * messages it seeds into the shared conversation get wiped by those cleanups.
+ *
+ * The fix is an isolated fixture: a throwaway user whose `sender_id` is NEVER
+ * named in any cleanupOldMessages call, in its own private conversation with
+ * PRIMARY, with a FIXED count of messages. Nothing else can see or delete it;
+ * the count never drifts across CI runs. Tear it down in afterAll via
+ * deleteScrollFixture() (cascades messages + conversation).
+ *
+ * The fixture user is given a public key so getMessageHistory doesn't hit its
+ * "other user has no public key → return []" path. Messages use placeholder
+ * encrypted_content (the viewer can't decrypt them, so each renders as an
+ * "Encrypted with previous keys" bubble) — which is still a real, visible,
+ * height-producing bubble. A scroll test only needs height, not readable text.
+ *
+ * @returns the throwaway user id and conversation id, or null on failure.
+ */
+export interface ScrollFixture {
+  fixtureUserId: string;
+  conversationId: string;
+}
+
+const SCROLL_FIXTURE_MARKER = '-scroll-fixture';
+
+export async function seedScrollFixture(
+  viewerEmail: string,
+  messageCount = 30
+): Promise<ScrollFixture | null> {
+  const admin = getAdminClient();
+  if (!admin) return null;
+
+  const viewer = await getUserByEmail(viewerEmail);
+  if (!viewer) {
+    console.warn('seedScrollFixture: viewer not found:', viewerEmail);
+    return null;
+  }
+
+  // 1. Create the throwaway partner (unique email → no collision, no other
+  //    spec references it, so no cleanupOldMessages ever deletes its messages).
+  //    The username MUST satisfy user_profiles' CHECK (length 3..30) — the
+  //    default email-prefix username overflows for long plus-aliased emails,
+  //    so pass a short explicit one.
+  const fixtureEmail = generateTestEmail('scroll-fixture');
+  const fixturePassword = 'ScrollFixturePass123!';
+  const fixtureUsername = `scrollfix${Date.now().toString().slice(-8)}`;
+  const fixtureUser = await createTestUser(fixtureEmail, fixturePassword, {
+    username: fixtureUsername,
+  });
+  if (!fixtureUser) {
+    console.warn('seedScrollFixture: failed to create fixture user');
+    return null;
+  }
+
+  // 2. Give the fixture user a public key so the viewer's getMessageHistory
+  //    can derive a shared secret instead of returning an empty thread.
+  const keysOk = await ensureEncryptionKeys(fixtureEmail, fixturePassword);
+  if (!keysOk) {
+    console.warn('seedScrollFixture: failed to create fixture keys');
+    await deleteTestUser(fixtureUser.id);
+    return null;
+  }
+
+  // 3. Create the private conversation (canonical sorted participant order).
+  const [p1, p2] =
+    viewer.id < fixtureUser.id
+      ? [viewer.id, fixtureUser.id]
+      : [fixtureUser.id, viewer.id];
+  const { data: conversation, error: convError } = await admin
+    .from('conversations')
+    .insert({ participant_1_id: p1, participant_2_id: p2 })
+    .select('id')
+    .single();
+  if (convError || !conversation) {
+    console.warn(
+      'seedScrollFixture: failed to create conversation:',
+      convError?.message
+    );
+    await deleteTestUser(fixtureUser.id);
+    return null;
+  }
+  const conversationId = conversation.id as string;
+
+  // 4. Insert a FIXED number of messages, alternating sender, timestamps
+  //    spread backwards so it reads like a real history.
+  const senders = [viewer.id, fixtureUser.id];
+  const now = Date.now();
+  const rows = Array.from({ length: messageCount }, (_, i) => ({
+    conversation_id: conversationId,
+    sender_id: senders[i % 2],
+    encrypted_content: `msg-${i + 1}${SCROLL_FIXTURE_MARKER}`,
+    initialization_vector: `iv-${i + 1}`,
+    sequence_number: i + 1,
+    created_at: new Date(
+      now - (messageCount - 1 - i) * 5 * 60 * 1000
+    ).toISOString(),
+  }));
+  const { error: insertError } = await admin.from('messages').insert(rows);
+  if (insertError) {
+    console.warn('seedScrollFixture: insert failed:', insertError.message);
+    await deleteTestUser(fixtureUser.id);
+    return null;
+  }
+
+  await admin
+    .from('conversations')
+    .update({ last_message_at: new Date(now).toISOString() })
+    .eq('id', conversationId);
+
+  console.log(
+    `✓ Scroll fixture: ${messageCount} messages in conversation ${conversationId} (fixture user ${fixtureUser.id})`
+  );
+  return { fixtureUserId: fixtureUser.id, conversationId };
+}
+
+/**
+ * Tear down the scroll fixture created by seedScrollFixture(). Deleting the
+ * throwaway user cascade-deletes its conversation and messages (FK ON DELETE
+ * CASCADE), so nothing is left behind. Safe to call with null.
+ */
+export async function deleteScrollFixture(
+  fixture: ScrollFixture | null
+): Promise<void> {
+  if (!fixture) return;
+  await deleteTestUser(fixture.fixtureUserId);
+  console.log('✓ Scroll fixture torn down');
+}
+
+/**
  * Scroll a message thread to the bottom so virtual-scrolled messages
  * at the end of the list are rendered in the DOM.
  */


### PR DESCRIPTION
## Summary

Makes messaging-scroll **T007-T008** actually verify the jump-to-bottom behavior. Previously it only asserted when the thread happened to be tall enough to scroll 500px+; on a short thread it **silently skipped**, passing green with zero coverage.

Closes #109.

## Why the two earlier attempts (PR #117) failed

Seeding the **shared** PRIMARY↔TERTIARY conversation didn't work: ~7 messaging specs call `cleanupOldMessages(PRIMARY, TERTIARY)` in their `beforeAll`, which deletes by **shared-user `sender_id`** — wiping any seed. That cleanup is deliberate: it keeps the shared conversation *short* so other specs' newly-sent messages don't fall outside the message virtualizer. messaging-scroll needs the **opposite** (a tall thread), so fighting over the shared users can't work.

## The fix — an isolated, static fixture

- **`seedScrollFixture()`** creates a **throwaway user** (`createTestUser`, with a short constraint-valid username), gives it a public key (`ensureEncryptionKeys`), opens a **private** conversation with PRIMARY, and inserts a **fixed 30 messages**. The throwaway user's `sender_id` is never named in any `cleanupOldMessages` call → nothing wipes it. 30 is static (never drifts) and stays under the 100-message virtualizer threshold.
- **`deleteScrollFixture()`** in `afterAll` deletes the user; FK `ON DELETE CASCADE` removes its conversation + messages. No pollution.
- **T007-T008** opens the fixture conversation **by id** (deterministic, not list-order dependent), **asserts** `distanceFromBottom > 500` (no more silent skip), and skips with a **clear logged reason** only if the fixture couldn't be built (no admin client / creds).

## Verification

This time the fix is verified in a **real browser locally**, not just reasoned about. Using the Docker MCP Playwright browser via **`http://127.0.0.1`** (a secure context where `crypto.subtle` is available — the earlier `host.docker.internal` origin is insecure, which is why local verification failed before):

```
bubbleCount:        30      (all fixture messages render)
encryptedPlaceholders: 30   ("Encrypted with previous keys" bubbles — height-producing)
scrollHeight:       3136
clientHeight:        258
distanceFromBottom:  600    (> 500 → the assertion passes)
```

Static gates: `type-check`, `eslint`, `prettier` all pass. CI's `*-msg` shards provide the cross-browser (chromium/firefox/webkit) confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
