### PR TITLE
feat(a11y): #80 dev-time axe accessibility overlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/ui": "^3.2.4",
     "argon2": "^0.44.0",
+    "axe-core": "^4.12.0",
     "axe-playwright": "^2.2.2",
     "canvas": "^3.2.0",
     "concurrently": "^9.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ importers:
       argon2:
         specifier: ^0.44.0
         version: 0.44.0
+      axe-core:
+        specifier: ^4.12.0
+        version: 4.12.0
       axe-playwright:
         specifier: ^2.2.2
         version: 2.2.2(playwright@1.55.0)
@@ -2594,6 +2597,10 @@ packages:
 
   axe-core@4.10.3:
     resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
+    engines: {node: '>=4'}
+
+  axe-core@4.12.0:
+    resolution: {integrity: sha512-FTavr/7Ba0IptwGOPxnQvdyW2tAsdLBMTBXz7rKH6xJ2skpyxpBxyHkDdBs4lf69yRqYpkqCdfhnwS8YULGOmg==}
     engines: {node: '>=4'}
 
   axe-html-reporter@2.2.11:
@@ -8151,7 +8158,7 @@ snapshots:
   '@storybook/addon-a11y@10.2.8(storybook@10.2.8(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
     dependencies:
       '@storybook/global': 5.0.0
-      axe-core: 4.10.3
+      axe-core: 4.12.0
       storybook: 10.2.8(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
   '@storybook/addon-docs@10.2.8(@types/react@19.1.13)(esbuild@0.25.9)(rollup@4.50.1)(storybook@10.2.8(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@7.1.5(@types/node@20.19.14)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.25.9))':
@@ -9355,16 +9362,18 @@ snapshots:
 
   axe-core@4.10.3: {}
 
-  axe-html-reporter@2.2.11(axe-core@4.10.3):
+  axe-core@4.12.0: {}
+
+  axe-html-reporter@2.2.11(axe-core@4.12.0):
     dependencies:
-      axe-core: 4.10.3
+      axe-core: 4.12.0
       mustache: 4.2.0
 
   axe-playwright@2.2.2(playwright@1.55.0):
     dependencies:
       '@types/junit-report-builder': 3.0.2
-      axe-core: 4.10.3
-      axe-html-reporter: 2.2.11(axe-core@4.10.3)
+      axe-core: 4.12.0
+      axe-html-reporter: 2.2.11(axe-core@4.12.0)
       junit-report-builder: 5.1.1
       picocolors: 1.1.1
       playwright: 1.55.0
@@ -10283,7 +10292,7 @@ snapshots:
       array-includes: 3.1.9
       array.prototype.flatmap: 1.3.3
       ast-types-flow: 0.0.8
-      axe-core: 4.10.3
+      axe-core: 4.12.0
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
@@ -11536,7 +11545,7 @@ snapshots:
     dependencies:
       '@paulirish/trace_engine': 0.0.59
       '@sentry/node': 9.46.0
-      axe-core: 4.10.3
+      axe-core: 4.12.0
       chrome-launcher: 1.2.1
       configstore: 7.1.0
       csp_evaluator: 1.1.5

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,6 +21,7 @@ import {
 import PWAInstall from '@/components/PWAInstall';
 import { CountdownBanner } from '@/components/atomic/CountdownBanner';
 import { SetupBanner } from '@/components/SetupBanner';
+import A11yDevOverlay from '@/components/organisms/A11yDevOverlay';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -135,6 +136,7 @@ export default function RootLayout({
               <CookieConsent />
               <ConsentModal />
               <PWAInstall />
+              {process.env.NODE_ENV === 'development' && <A11yDevOverlay />}
             </AccessibilityProvider>
           </AuthProvider>
         </ConsentProvider>

--- a/src/components/organisms/A11yDevOverlay/A11yDevOverlay.accessibility.test.tsx
+++ b/src/components/organisms/A11yDevOverlay/A11yDevOverlay.accessibility.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import type { Result } from 'axe-core';
+import A11yDevOverlay from './A11yDevOverlay';
+
+// usePathname() is called by the scan hook; mock it so the hook is inert in jsdom.
+vi.mock('next/navigation', () => ({
+  usePathname: vi.fn(() => '/'),
+}));
+
+vi.mock('axe-core', () => ({
+  default: { run: vi.fn().mockResolvedValue({ violations: [] }) },
+}));
+
+expect.extend(toHaveNoViolations);
+
+const mockViolations: Result[] = [
+  {
+    id: 'button-name',
+    impact: 'critical',
+    description: 'Buttons must have discernible text',
+    help: 'Buttons must have discernible text',
+    helpUrl: 'https://dequeuniversity.com/rules/axe/button-name',
+    tags: ['wcag2a'],
+    nodes: [
+      {
+        html: '<button></button>',
+        target: ['#target'],
+        any: [],
+        all: [],
+        none: [],
+        failureSummary: 'Fix this',
+      },
+    ],
+  },
+  {
+    id: 'color-contrast',
+    impact: 'serious',
+    description: 'Elements must meet contrast thresholds',
+    help: 'Elements must have sufficient color contrast',
+    helpUrl: 'https://dequeuniversity.com/rules/axe/color-contrast',
+    tags: ['wcag2aa'],
+    nodes: [
+      {
+        html: '<p></p>',
+        target: ['p'],
+        any: [],
+        all: [],
+        none: [],
+        failureSummary: 'Fix this',
+      },
+    ],
+  },
+];
+
+describe('A11yDevOverlay Accessibility', () => {
+  it('should have no accessibility violations when expanded with violations', async () => {
+    const { container } = render(
+      <A11yDevOverlay violations={mockViolations} defaultExpanded />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('should have no accessibility violations in the collapsed badge state', async () => {
+    const { container } = render(
+      <A11yDevOverlay violations={mockViolations} />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('should have focusable elements in proper tab order', () => {
+    const { container } = render(
+      <A11yDevOverlay violations={mockViolations} defaultExpanded />
+    );
+
+    const focusableElements = container.querySelectorAll(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+
+    focusableElements.forEach((element) => {
+      expect(element).toBeVisible();
+    });
+  });
+});

--- a/src/components/organisms/A11yDevOverlay/A11yDevOverlay.stories.tsx
+++ b/src/components/organisms/A11yDevOverlay/A11yDevOverlay.stories.tsx
@@ -1,0 +1,134 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import type { Result } from 'axe-core';
+import A11yDevOverlay from './A11yDevOverlay';
+
+const mockViolations: Result[] = [
+  {
+    id: 'button-name',
+    impact: 'critical',
+    description: 'Buttons must have discernible text',
+    help: 'Buttons must have discernible text',
+    helpUrl: 'https://dequeuniversity.com/rules/axe/button-name',
+    tags: ['wcag2a', 'wcag412'],
+    nodes: [
+      {
+        html: '<button class="icon-only"></button>',
+        target: ['.icon-only'],
+        any: [],
+        all: [],
+        none: [],
+        failureSummary: 'Element has no discernible text',
+      },
+    ],
+  },
+  {
+    id: 'color-contrast',
+    impact: 'serious',
+    description: 'Elements must meet minimum color contrast ratio thresholds',
+    help: 'Elements must have sufficient color contrast',
+    helpUrl: 'https://dequeuniversity.com/rules/axe/color-contrast',
+    tags: ['wcag2aa', 'wcag143'],
+    nodes: [
+      {
+        html: '<p class="muted">Low contrast text</p>',
+        target: ['.muted'],
+        any: [],
+        all: [],
+        none: [],
+        failureSummary: 'Contrast ratio is below 4.5:1',
+      },
+    ],
+  },
+  {
+    id: 'label',
+    impact: 'moderate',
+    description: 'Form elements must have labels',
+    help: 'Form elements must have labels',
+    helpUrl: 'https://dequeuniversity.com/rules/axe/label',
+    tags: ['wcag2a', 'wcag412'],
+    nodes: [
+      {
+        html: '<input type="text" />',
+        target: ['input'],
+        any: [],
+        all: [],
+        none: [],
+        failureSummary: 'Form element has no label',
+      },
+    ],
+  },
+  {
+    id: 'region',
+    impact: 'minor',
+    description: 'All page content should be contained by landmarks',
+    help: 'All page content should be contained by landmarks',
+    helpUrl: 'https://dequeuniversity.com/rules/axe/region',
+    tags: ['best-practice'],
+    nodes: [
+      {
+        html: '<div class="loose"></div>',
+        target: ['.loose'],
+        any: [],
+        all: [],
+        none: [],
+        failureSummary: 'Content is not inside a landmark',
+      },
+    ],
+  },
+];
+
+const meta: Meta<typeof A11yDevOverlay> = {
+  title: 'Components/Organisms/A11yDevOverlay',
+  component: A11yDevOverlay,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Dev-only floating accessibility overlay. In the real app it runs a live axe-core ' +
+          'scan; these stories pass deterministic mock violations via the `violations` prop. ' +
+          'A collapsed badge shows the count (color-coded by worst impact) and expands into a ' +
+          'panel with impact filters, rule-id search, and click-to-highlight.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    violations: {
+      control: false,
+      description: 'axe-core violations to display (overrides the live scan).',
+    },
+    defaultExpanded: {
+      control: 'boolean',
+      description: 'Start in the expanded panel state.',
+    },
+    className: {
+      control: 'text',
+      description: 'Additional CSS classes',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  args: {
+    violations: [],
+    defaultExpanded: true,
+  },
+};
+
+export const WithViolations: Story = {
+  args: {
+    violations: mockViolations,
+    defaultExpanded: true,
+  },
+};
+
+export const CollapsedButton: Story = {
+  args: {
+    violations: mockViolations,
+    defaultExpanded: false,
+  },
+};

--- a/src/components/organisms/A11yDevOverlay/A11yDevOverlay.test.tsx
+++ b/src/components/organisms/A11yDevOverlay/A11yDevOverlay.test.tsx
@@ -1,0 +1,162 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Result } from 'axe-core';
+import A11yDevOverlay from './A11yDevOverlay';
+
+// The overlay's hook calls usePathname(); the live axe import is never reached in tests
+// because violations are passed as a prop (controlled mode).
+vi.mock('next/navigation', () => ({
+  usePathname: vi.fn(() => '/'),
+}));
+
+// Guard against any accidental real scan.
+vi.mock('axe-core', () => ({
+  default: { run: vi.fn().mockResolvedValue({ violations: [] }) },
+}));
+
+function makeViolation(overrides: Partial<Result> & { id: string }): Result {
+  return {
+    id: overrides.id,
+    impact: overrides.impact ?? 'moderate',
+    description: overrides.description ?? `${overrides.id} description`,
+    help: overrides.help ?? `${overrides.id} help text`,
+    helpUrl:
+      overrides.helpUrl ??
+      `https://dequeuniversity.com/rules/axe/${overrides.id}`,
+    tags: overrides.tags ?? ['wcag2aa'],
+    nodes: overrides.nodes ?? [
+      {
+        html: '<button></button>',
+        target: ['#target'],
+        any: [],
+        all: [],
+        none: [],
+        failureSummary: 'Fix this',
+      },
+    ],
+  };
+}
+
+const mockViolations: Result[] = [
+  makeViolation({ id: 'button-name', impact: 'critical' }),
+  makeViolation({ id: 'color-contrast', impact: 'serious' }),
+  makeViolation({ id: 'label', impact: 'moderate' }),
+  makeViolation({ id: 'region', impact: 'minor' }),
+];
+
+describe('A11yDevOverlay', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the collapsed badge with the violation count', () => {
+    render(<A11yDevOverlay violations={mockViolations} />);
+    const badge = screen.getByRole('button', {
+      name: /accessibility violations: 4/i,
+    });
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent('4');
+  });
+
+  it('colors the badge by worst impact (critical → error)', () => {
+    render(
+      <A11yDevOverlay
+        violations={[makeViolation({ id: 'button-name', impact: 'critical' })]}
+      />
+    );
+    const badge = screen.getByRole('button', {
+      name: /accessibility violations: 1/i,
+    });
+    expect(badge).toHaveClass('badge-error');
+  });
+
+  it('expands to a panel showing rule id, impact, selector, and a help link', () => {
+    render(<A11yDevOverlay violations={mockViolations} />);
+    fireEvent.click(
+      screen.getByRole('button', { name: /accessibility violations/i })
+    );
+
+    expect(
+      screen.getByRole('region', { name: /accessibility violations panel/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText('button-name')).toBeInTheDocument();
+
+    const link = screen.getAllByRole('link', { name: /learn more/i })[0];
+    expect(link).toHaveAttribute(
+      'href',
+      expect.stringContaining('dequeuniversity.com')
+    );
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noreferrer');
+  });
+
+  it('renders a zero-state when there are no violations', () => {
+    render(<A11yDevOverlay violations={[]} defaultExpanded />);
+    expect(
+      screen.getByText(/no accessibility violations/i)
+    ).toBeInTheDocument();
+  });
+
+  it('filters by impact chip and searches by rule id', () => {
+    render(<A11yDevOverlay violations={mockViolations} defaultExpanded />);
+
+    // Filter to only "critical" — button-name should remain, color-contrast should not.
+    fireEvent.click(screen.getByRole('button', { name: 'critical' }));
+    expect(screen.getByText('button-name')).toBeInTheDocument();
+    expect(screen.queryByText('color-contrast')).not.toBeInTheDocument();
+
+    // Clear the filter, then search by rule id.
+    fireEvent.click(screen.getByRole('button', { name: 'critical' }));
+    fireEvent.change(
+      screen.getByRole('searchbox', {
+        name: /search violations by rule id/i,
+      }),
+      { target: { value: 'contrast' } }
+    );
+    expect(screen.getByText('color-contrast')).toBeInTheDocument();
+    expect(screen.queryByText('button-name')).not.toBeInTheDocument();
+  });
+
+  it('highlights the target element on click and cleans up after the timeout', () => {
+    vi.useFakeTimers();
+    const target = document.createElement('button');
+    target.id = 'target';
+    target.scrollIntoView = vi.fn();
+    document.body.appendChild(target);
+
+    render(
+      <A11yDevOverlay
+        violations={[makeViolation({ id: 'button-name', impact: 'critical' })]}
+        defaultExpanded
+      />
+    );
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /highlight element for button-name/i,
+      })
+    );
+
+    expect(target.scrollIntoView).toHaveBeenCalled();
+    expect(target.style.outline).not.toBe('');
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(target.style.outline).toBe('');
+
+    target.remove();
+    vi.useRealTimers();
+  });
+
+  it('applies a custom className', () => {
+    render(
+      <A11yDevOverlay
+        violations={mockViolations}
+        className="custom-test-class"
+      />
+    );
+    expect(
+      screen.getByRole('button', { name: /accessibility violations/i })
+    ).toHaveClass('custom-test-class');
+  });
+});

--- a/src/components/organisms/A11yDevOverlay/A11yDevOverlay.tsx
+++ b/src/components/organisms/A11yDevOverlay/A11yDevOverlay.tsx
@@ -1,0 +1,300 @@
+'use client';
+
+import React, { useMemo, useRef, useState } from 'react';
+import type { ImpactValue, Result } from 'axe-core';
+import { useA11yScan } from './useA11yScan';
+
+export interface A11yDevOverlayProps {
+  /**
+   * Override violations instead of running a live axe scan. When provided, the internal
+   * scan hook is bypassed — used by tests and Storybook to render deterministic states.
+   */
+  violations?: Result[];
+  /** Start in the expanded (panel) state instead of the collapsed badge. */
+  defaultExpanded?: boolean;
+  /** Additional CSS classes applied to the root element. */
+  className?: string;
+}
+
+/** Impact levels, ordered most → least severe. Drives sort order, badge color, and worst-impact. */
+const IMPACT_ORDER: Exclude<ImpactValue, null>[] = [
+  'critical',
+  'serious',
+  'moderate',
+  'minor',
+];
+
+/** Maps an axe impact level to a DaisyUI badge/alert color class. */
+const IMPACT_BADGE_CLASS: Record<Exclude<ImpactValue, null>, string> = {
+  critical: 'badge-error',
+  serious: 'badge-error',
+  moderate: 'badge-warning',
+  minor: 'badge-warning',
+};
+
+/** How long (ms) a click-to-highlight outline stays on the target element. */
+const HIGHLIGHT_DURATION_MS = 3000;
+
+/** Inline outline applied to a highlighted target element. */
+const HIGHLIGHT_OUTLINE = '3px solid #f43f5e';
+
+function impactRank(impact: ImpactValue | undefined): number {
+  if (!impact) return IMPACT_ORDER.length;
+  const idx = IMPACT_ORDER.indexOf(impact);
+  return idx === -1 ? IMPACT_ORDER.length : idx;
+}
+
+/**
+ * Dev-time accessibility overlay.
+ *
+ * A floating badge (color-coded by worst violation impact) that expands into a panel listing
+ * the current axe-core violations. Supports filtering by impact, searching by rule id, and
+ * click-to-highlight of the offending element.
+ *
+ * Rendering is gated to development: in production the bundler strips the mount in `layout.tsx`,
+ * and this component additionally returns `null` when not in development unless explicit
+ * `violations` are supplied (the path tests/Storybook use).
+ *
+ * @category organisms
+ */
+export default function A11yDevOverlay({
+  violations: violationsProp,
+  defaultExpanded = false,
+  className = '',
+}: A11yDevOverlayProps) {
+  const scan = useA11yScan();
+  const isControlled = violationsProp !== undefined;
+  const violations = isControlled ? violationsProp : scan.violations;
+
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const [activeImpacts, setActiveImpacts] = useState<
+    Set<Exclude<ImpactValue, null>>
+  >(new Set());
+  const [search, setSearch] = useState('');
+
+  // Tracks the currently highlighted element + its cleanup timer so re-clicks don't leak outlines.
+  const highlightRef = useRef<{
+    el: HTMLElement;
+    timer: ReturnType<typeof setTimeout>;
+  } | null>(null);
+
+  const worstImpact = useMemo<ImpactValue>(
+    () =>
+      violations.reduce<ImpactValue>(
+        (worst, v) =>
+          impactRank(v.impact) < impactRank(worst)
+            ? (v.impact ?? worst)
+            : worst,
+        null
+      ),
+    [violations]
+  );
+
+  const visibleViolations = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return [...violations]
+      .filter((v) => {
+        if (activeImpacts.size > 0) {
+          if (!v.impact || !activeImpacts.has(v.impact)) return false;
+        }
+        if (query && !v.id.toLowerCase().includes(query)) return false;
+        return true;
+      })
+      .sort((a, b) => impactRank(a.impact) - impactRank(b.impact));
+  }, [violations, activeImpacts, search]);
+
+  // Don't render anything in non-dev environments unless violations are explicitly supplied.
+  // Placed after all hooks so the Rules of Hooks are never violated.
+  if (!isControlled && process.env.NODE_ENV !== 'development') {
+    return null;
+  }
+
+  const toggleImpact = (impact: Exclude<ImpactValue, null>) => {
+    setActiveImpacts((prev) => {
+      const next = new Set(prev);
+      if (next.has(impact)) next.delete(impact);
+      else next.add(impact);
+      return next;
+    });
+  };
+
+  const clearHighlight = () => {
+    const current = highlightRef.current;
+    if (current) {
+      clearTimeout(current.timer);
+      current.el.style.outline = '';
+      current.el.style.outlineOffset = '';
+      highlightRef.current = null;
+    }
+  };
+
+  const highlightViolation = (violation: Result) => {
+    const node = violation.nodes[0];
+    // axe `target` is an array of selectors; >1 entry means the node lives inside nested iframes,
+    // which we can't reach via a single `querySelector`. Handle the common single-selector case.
+    const selector =
+      node && node.target.length === 1 && typeof node.target[0] === 'string'
+        ? node.target[0]
+        : null;
+    if (!selector) return;
+
+    let el: HTMLElement | null = null;
+    try {
+      el = document.querySelector<HTMLElement>(selector);
+    } catch {
+      el = null;
+    }
+    if (!el) return;
+
+    clearHighlight();
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    el.style.outline = HIGHLIGHT_OUTLINE;
+    el.style.outlineOffset = '2px';
+    const timer = setTimeout(clearHighlight, HIGHLIGHT_DURATION_MS);
+    highlightRef.current = { el, timer };
+  };
+
+  const badgeColor = worstImpact
+    ? IMPACT_BADGE_CLASS[worstImpact]
+    : 'badge-success';
+
+  // Collapsed badge — a floating button showing the violation count.
+  if (!expanded) {
+    return (
+      <button
+        type="button"
+        onClick={() => setExpanded(true)}
+        aria-label={`Accessibility violations: ${violations.length}. Open panel.`}
+        className={`badge ${badgeColor} fixed right-4 bottom-20 z-[90] flex min-h-11 min-w-11 cursor-pointer items-center gap-1 rounded-full px-3 shadow-lg ${className}`}
+      >
+        <span role="img" aria-hidden="true">
+          ♿
+        </span>
+        <span className="font-mono font-bold">{violations.length}</span>
+      </button>
+    );
+  }
+
+  // Expanded panel.
+  return (
+    <section
+      role="region"
+      aria-label="Accessibility violations panel"
+      className={`bg-base-100 border-base-300 text-base-content fixed right-4 bottom-20 z-[90] flex max-h-[70vh] w-80 flex-col rounded-lg border shadow-lg ${className}`}
+    >
+      <header className="border-base-300 flex items-center justify-between gap-2 border-b px-3 py-2">
+        <h2 className="flex items-center gap-2 text-sm font-bold">
+          <span role="img" aria-hidden="true">
+            ♿
+          </span>
+          A11y
+          <span className={`badge badge-sm ${badgeColor}`}>
+            {violations.length}
+          </span>
+        </h2>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => scan.rescan()}
+            disabled={isControlled || scan.isScanning}
+            aria-label="Re-scan page for accessibility violations"
+            className="btn btn-ghost btn-xs min-h-11 min-w-11"
+          >
+            {scan.isScanning ? '…' : '↻'}
+          </button>
+          <button
+            type="button"
+            onClick={() => setExpanded(false)}
+            aria-label="Collapse accessibility panel"
+            className="btn btn-ghost btn-xs min-h-11 min-w-11"
+          >
+            ✕
+          </button>
+        </div>
+      </header>
+
+      <div className="border-base-300 flex flex-col gap-2 border-b px-3 py-2">
+        <div
+          className="flex flex-wrap gap-1"
+          role="group"
+          aria-label="Filter by impact"
+        >
+          {IMPACT_ORDER.map((impact) => (
+            <button
+              key={impact}
+              type="button"
+              onClick={() => toggleImpact(impact)}
+              aria-pressed={activeImpacts.has(impact)}
+              className={`badge badge-sm cursor-pointer ${
+                activeImpacts.has(impact)
+                  ? IMPACT_BADGE_CLASS[impact]
+                  : 'badge-ghost'
+              }`}
+            >
+              {impact}
+            </button>
+          ))}
+        </div>
+        <input
+          type="search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search by rule id…"
+          aria-label="Search violations by rule id"
+          className="input input-bordered input-xs w-full"
+        />
+      </div>
+
+      <ul className="flex-1 overflow-y-auto" aria-live="polite">
+        {visibleViolations.length === 0 ? (
+          <li className="text-base-content/60 p-4 text-center text-sm">
+            {violations.length === 0
+              ? 'No accessibility violations 🎉'
+              : 'No violations match the current filters.'}
+          </li>
+        ) : (
+          visibleViolations.map((violation) => (
+            <li
+              key={violation.id}
+              className="border-base-300 border-b px-3 py-2 text-sm last:border-b-0"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <code className="text-xs font-bold">{violation.id}</code>
+                {violation.impact && (
+                  <span
+                    className={`badge badge-xs ${IMPACT_BADGE_CLASS[violation.impact]}`}
+                  >
+                    {violation.impact}
+                  </span>
+                )}
+              </div>
+              <p className="text-base-content/80 mt-1 text-xs">
+                {violation.help}
+              </p>
+              {violation.nodes[0]?.target[0] && (
+                <button
+                  type="button"
+                  onClick={() => highlightViolation(violation)}
+                  aria-label={`Highlight element for ${violation.id}`}
+                  className="mt-1 block w-full truncate text-left"
+                >
+                  <code className="link link-primary text-xs">
+                    {String(violation.nodes[0].target[0])}
+                  </code>
+                </button>
+              )}
+              <a
+                href={violation.helpUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="link link-secondary mt-1 inline-block text-xs"
+              >
+                Learn more →
+              </a>
+            </li>
+          ))
+        )}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/organisms/A11yDevOverlay/index.tsx
+++ b/src/components/organisms/A11yDevOverlay/index.tsx
@@ -1,0 +1,2 @@
+export { default } from './A11yDevOverlay';
+export type { A11yDevOverlayProps } from './A11yDevOverlay';

--- a/src/components/organisms/A11yDevOverlay/useA11yScan.ts
+++ b/src/components/organisms/A11yDevOverlay/useA11yScan.ts
@@ -1,0 +1,119 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import type { Result } from 'axe-core';
+
+/**
+ * Shape returned by {@link useA11yScan}.
+ */
+export interface UseA11yScanResult {
+  /** Current axe-core violations for the live document. */
+  violations: Result[];
+  /** True while an axe scan is in flight. */
+  isScanning: boolean;
+  /** Epoch ms of the last completed scan, or null if none has run. */
+  lastScanAt: number | null;
+  /** Manually trigger a (debounced) re-scan. */
+  rescan: () => void;
+}
+
+/** Debounce window (ms) that coalesces route changes, DOM mutations, and StrictMode double-effects. */
+const SCAN_DEBOUNCE_MS = 500;
+
+/**
+ * Loads axe-core, but ONLY in development.
+ *
+ * The `import('axe-core')` is wrapped in a literal `process.env.NODE_ENV === 'development'`
+ * check so that Next.js's DefinePlugin replaces the condition with `false` in production
+ * builds and webpack statically eliminates the dynamic import (and the ~1.3 MB axe-core
+ * engine) from the bundle. The comparison MUST be lexically adjacent to `import()` — routing
+ * it through an `enabled` variable defeats webpack's dead-code analysis and ships axe to prod.
+ */
+async function loadAxe() {
+  if (process.env.NODE_ENV === 'development') {
+    return (await import('axe-core')).default;
+  }
+  return null;
+}
+
+/**
+ * Owns the dev-only axe-core scan lifecycle for {@link A11yDevOverlay}.
+ *
+ * Responsibilities:
+ * - Dynamically `import('axe-core')` ONLY in development, inside the gated branch, so the
+ *   production static export tree-shakes the dependency out entirely.
+ * - Scan on mount, on App Router route change (`usePathname`), on debounced DOM mutations
+ *   (MutationObserver), and on manual `rescan()`.
+ *
+ * In any non-development environment (production, test) the hook is inert: it returns empty
+ * state and never imports axe-core, so component tests can render deterministically without
+ * invoking a real scan.
+ */
+export function useA11yScan(): UseA11yScanResult {
+  const enabled = process.env.NODE_ENV === 'development';
+  const pathname = usePathname();
+
+  const [violations, setViolations] = useState<Result[]>([]);
+  const [isScanning, setIsScanning] = useState(false);
+  const [lastScanAt, setLastScanAt] = useState<number | null>(null);
+
+  // Refs avoid stale closures and let cleanup cancel in-flight work.
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const scanningRef = useRef(false);
+  const mountedRef = useRef(true);
+
+  const runScan = useCallback(async () => {
+    if (!enabled || scanningRef.current) return;
+    scanningRef.current = true;
+    setIsScanning(true);
+    try {
+      const axe = await loadAxe();
+      if (!axe) return;
+      const results = await axe.run(document, { resultTypes: ['violations'] });
+      if (!mountedRef.current) return;
+      setViolations(results.violations);
+      setLastScanAt(Date.now());
+    } catch {
+      // A failed scan must never break the host app; surface nothing and keep prior results.
+    } finally {
+      scanningRef.current = false;
+      if (mountedRef.current) setIsScanning(false);
+    }
+  }, [enabled]);
+
+  const scheduleScan = useCallback(() => {
+    if (!enabled) return;
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      void runScan();
+    }, SCAN_DEBOUNCE_MS);
+  }, [enabled, runScan]);
+
+  // Scan on mount and whenever the route changes.
+  useEffect(() => {
+    if (!enabled) return;
+    scheduleScan();
+  }, [enabled, pathname, scheduleScan]);
+
+  // Re-scan (debounced) when the DOM changes — covers client-side content that renders after navigation.
+  useEffect(() => {
+    if (!enabled || typeof MutationObserver === 'undefined') return;
+    const observer = new MutationObserver(() => scheduleScan());
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+    });
+    return () => observer.disconnect();
+  }, [enabled, scheduleScan]);
+
+  // Track mount state and clear any pending debounce on unmount.
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  return { violations, isScanning, lastScanAt, rescan: scheduleScan };
+}


### PR DESCRIPTION
Closes #80.

## What

Adds **`A11yDevOverlay`** — a dev-only floating panel that runs `axe-core` against the live DOM and surfaces accessibility violations as you develop. Fulfils the deferred "real-time dev feedback dashboard" from `features/foundation/001-wcag-aa-compliance/spec.md` (User Story 8, FR-028/029/030).

## UX

A collapsed badge in the corner (♿ + violation count, color-coded by worst impact) that expands into a panel with:
- Violation list — rule id, impact badge, help text, target selector, and a link to the axe rule docs (`helpUrl`)
- **Filter chips** (critical / serious / moderate / minor)
- **Search** by rule id
- **Click-to-highlight** — outlines the offending element on the page (auto-clears after 3s)
- Manual **Re-scan** + collapse

Scans on mount, route change (`usePathname`), and DOM mutations (`MutationObserver`), all debounced 500ms.

## Strictly dev-only (verified)

Three guards ensure it never ships to the GitHub Pages production export:
1. The mount in `layout.tsx` is wrapped in `process.env.NODE_ENV === 'development'` → DefinePlugin makes it `false &&` in prod → dropped.
2. The component early-returns `null` outside development.
3. The `import('axe-core')` lives inside a **literal** `NODE_ENV === 'development'` check in `loadAxe()`, so webpack statically eliminates it (routing it through a variable would defeat dead-code analysis and ship axe to prod).

**Build verification:** production `out/` served chunks contain the overlay referenced **0×** and the full ~1.3 MB axe engine is **fully stripped** (`vendor.js` shrank 576 KB). `axe-core` is a **devDependency**.

## Architecture

Presentational `A11yDevOverlay.tsx` (prop-driven, testable, Storybook-able) + `useA11yScan.ts` hook owning the scan lifecycle — mirrors the existing `ChatWindow`/`useChatWindow` split. No CSP changes (axe runs client-side only on the existing DOM, no network).

## Tests & gates

- 7 unit + 3 a11y tests (green); full suite **3340/3340** passing
- 3 Storybook stories (Empty, WithViolations, CollapsedButton)
- `validate:structure` (5-file pattern) ✓, type-check ✓, lint ✓, prettier ✓, build ✓, build-storybook ✓
- **Live E2E verified** via the dev server: badge showed a real `landmark-unique` finding; filter, search, and click-to-highlight all work; 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)