### PR TITLE
perf(e2e): #116 lower CI Argon2 key-derivation cost (E2E-only)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    - cron: '0 6 * * 1'  # Monday 6 AM UTC — full 3-browser run
+    - cron: '0 6 * * 1' # Monday 6 AM UTC — full 3-browser run
   workflow_dispatch:
 
 concurrency:
@@ -65,6 +65,13 @@ jobs:
           # test.skip'd; the rest only assert UI render + consent flow.
           NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: pk_test_e2e_dummy_not_a_real_key
           NEXT_PUBLIC_PAYPAL_CLIENT_ID: e2e_dummy_paypal_client_id
+          # E2E-ONLY: lower Argon2id key-derivation cost from 3 → 1 iteration.
+          # Argon2 runs in-browser (hash-wasm) on every login/re-auth, so the
+          # messaging specs pay ~10s/test for it. Derived keys stay valid; only
+          # brute-force hardness drops, which is irrelevant for throwaway CI
+          # users. Read+clamped in src/types/messaging.ts (ARGON2_CONFIG).
+          # NEVER set this in deploy.yml — the production build derives at 3.
+          NEXT_PUBLIC_E2E_ARGON2_TIME_COST: 1
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/src/lib/messaging/__tests__/key-derivation.test.ts
+++ b/src/lib/messaging/__tests__/key-derivation.test.ts
@@ -10,7 +10,12 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { KeyDerivationService } from '../key-derivation';
-import { ARGON2_CONFIG, CRYPTO_PARAMS } from '@/types/messaging';
+import {
+  ARGON2_CONFIG,
+  CRYPTO_PARAMS,
+  PROD_ARGON2_TIME_COST,
+  resolveArgon2TimeCost,
+} from '@/types/messaging';
 
 describe('KeyDerivationService', () => {
   let service: KeyDerivationService;
@@ -374,5 +379,37 @@ describe('KeyDerivationService', () => {
 
       expect(decrypted).toBe(plaintext);
     });
+  });
+});
+
+describe('resolveArgon2TimeCost (E2E override security contract)', () => {
+  it('defaults to the production cost when no override is set', () => {
+    expect(resolveArgon2TimeCost(undefined)).toBe(PROD_ARGON2_TIME_COST);
+    expect(resolveArgon2TimeCost('')).toBe(PROD_ARGON2_TIME_COST);
+    expect(PROD_ARGON2_TIME_COST).toBe(3);
+  });
+
+  it('falls back to the production cost for non-numeric input', () => {
+    expect(resolveArgon2TimeCost('abc')).toBe(PROD_ARGON2_TIME_COST);
+    expect(resolveArgon2TimeCost('NaN')).toBe(PROD_ARGON2_TIME_COST);
+  });
+
+  it('allows lowering the cost to a valid E2E value', () => {
+    expect(resolveArgon2TimeCost('1')).toBe(1);
+    expect(resolveArgon2TimeCost('2')).toBe(2);
+  });
+
+  it('NEVER lets the override raise the cost above production', () => {
+    expect(resolveArgon2TimeCost('4')).toBe(PROD_ARGON2_TIME_COST);
+    expect(resolveArgon2TimeCost('99')).toBe(PROD_ARGON2_TIME_COST);
+  });
+
+  it('clamps zero / negative input up to the minimum of 1', () => {
+    expect(resolveArgon2TimeCost('0')).toBe(1);
+    expect(resolveArgon2TimeCost('-5')).toBe(1);
+  });
+
+  it('the live ARGON2_CONFIG.TIME_COST matches the resolver', () => {
+    expect(ARGON2_CONFIG.TIME_COST).toBe(resolveArgon2TimeCost());
   });
 });

--- a/src/types/messaging.ts
+++ b/src/types/messaging.ts
@@ -469,13 +469,45 @@ export const CRYPTO_PARAMS = {
 } as const;
 
 /**
+ * Production Argon2 time cost (OWASP-recommended, per FR-001).
+ *
+ * The E2E suite may override this DOWNWARD via `NEXT_PUBLIC_E2E_ARGON2_TIME_COST`
+ * to cut per-test key-derivation time — Argon2id runs in the browser (hash-wasm),
+ * so the cost is paid on every login/re-auth in the messaging E2E specs (~10s/test).
+ * The override:
+ *  - is read ONLY here, defaults to 3, and is clamped to [1, 3] so it can never be
+ *    raised or set to a nonsense value;
+ *  - is gated on `NEXT_PUBLIC_E2E_ARGON2_TIME_COST` being explicitly set — the
+ *    production deploy (`deploy.yml`) never sets it, so prod always derives at 3.
+ * The derived keys are cryptographically valid at any iteration count; lowering
+ * iterations only reduces brute-force hardness, which is irrelevant for throwaway
+ * CI test users. NEVER set this variable in a real deployment.
+ */
+export const PROD_ARGON2_TIME_COST = 3;
+
+/**
+ * Resolves the Argon2 time cost from an optional E2E override string.
+ * Exported (pure) for unit testing the security contract: the override may only
+ * LOWER cost to [1, PROD], and any absent/invalid value falls back to PROD.
+ */
+export function resolveArgon2TimeCost(
+  raw: string | undefined = process.env.NEXT_PUBLIC_E2E_ARGON2_TIME_COST
+): number {
+  if (!raw) return PROD_ARGON2_TIME_COST;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) return PROD_ARGON2_TIME_COST;
+  // Clamp to [1, prod]: the override may only LOWER cost, never raise it.
+  return Math.min(Math.max(parsed, 1), PROD_ARGON2_TIME_COST);
+}
+
+/**
  * Argon2 configuration (OWASP recommended for password hashing)
  * Per FR-001: Argon2id with memory=65536 (64MB), timeCost=3, parallelism=4, hashLength=32
  */
 export const ARGON2_CONFIG = {
   TYPE: 'argon2id', // Hybrid of argon2i and argon2d (best for passwords)
   MEMORY_COST: 65536, // 64 MB
-  TIME_COST: 3, // 3 iterations
+  TIME_COST: resolveArgon2TimeCost(), // 3 in prod; E2E may lower via env (see above)
   PARALLELISM: 4, // 4 parallel lanes
   HASH_LENGTH: 32, // 256 bits for P-256 seed
   SALT_LENGTH: 16, // 16 bytes


### PR DESCRIPTION
Part of #116 (Phase 1 of 2). The free, low-risk wins; the parallelism rework (Phase 2) is separate follow-up.

## Profiling (real data, not hypotheses)

Pulled the Playwright blob report from PR #119's green run — **chromium-msg shard, 80 tests, 26.9 min, effectively serial**. Step-level breakdown:

| Total | Count | Avg | Step |
|---|---|---|---|
| **10.5 min** | 21× | **30,001 ms (timeout)** | `body[data-messages-subscribed]` wait |
| ~20 min | 137× | ~8–10s | `Before Hooks` + `beforeEach` (Argon2 derivation) |
| 9.2 min | 152× | 3.6s | `encryption-key-gate-loading` wait |
| 6.1 min | 400× | 0.9s | hard-coded `waitForTimeout` |

## What this PR fixes

**1. Removed the dead `data-messages-subscribed` waits (−10.5 min/shard).**
The attribute is referenced **0× in `src/`** — the message thread does **not** use Supabase Realtime. Cross-window delivery is a **10s poll** (`ConversationView.tsx:236`) because the app is a static export with no realtime server. All four waits (`real-time-delivery.spec.ts` ×3, `encrypted-messaging.spec.ts` ×1) wrapped the selector in `try/catch` and **always burned the full 30s** before falling through to the reload-retry that actually works. Removed them; corrected the misleading "Realtime subscription" comments to describe the real poll-based delivery.

**2. E2E-only Argon2 cost reduction (−4–5 min/shard).**
Argon2id runs in-browser (`hash-wasm`) on every login/re-auth (~10s/test). Added `NEXT_PUBLIC_E2E_ARGON2_TIME_COST`, read + **clamped to [1,3]** in `ARGON2_CONFIG` (`src/types/messaging.ts`). `e2e.yml` sets it to `1`; `deploy.yml` never sets it → **production always derives at 3**. Verified at the bundle level (built with env → inlines 1; without → returns 3; clamp prevents raising). 6 unit tests pin the security contract.

## Expected impact
- Shard: **~28 → ~14–16 min** · Chain: **~83 → ~45–55 min**

## Deliberately NOT done (scope discipline)
- **Phase 1c sleep conversions skipped.** The remaining 6.1 min of `waitForTimeout` is load-bearing replication / reload-retry waits that keep the suite stable (10 rounds of flake-fixing). The only safe candidates save ~30s — not worth the flake risk per "stability over speed."
- **The single-shard / data-race constraint is untouched.** Per-test fixture isolation (the #109 pattern) that unlocks `workers>1` + sub-sharding is Phase 2 follow-up.

Full root-cause analysis posted on #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)