### PR TITLE
test(messaging): #41 unit tests for 4 untested messaging/auth services (130 tests)

### DIFF
--- a/src/services/auth/__tests__/audit-logger.test.ts
+++ b/src/services/auth/__tests__/audit-logger.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Unit Test: AuditLogger
+ *
+ * Tests the authentication audit logger with a mocked Supabase client and a
+ * mocked logger. No network dependency - fast, reliable unit tests.
+ *
+ * Key behaviors verified:
+ *  - each public logger method inserts into 'auth_audit_logs' with the correct
+ *    event_type (and user_id / event_data shape)
+ *  - stripCredentials() removes any event_data field whose name matches
+ *    /password|token|secret|key|credential/i before persisting
+ *  - extractRequestInfo() pulls ip_address + user_agent from a Request-like
+ *    object ({ headers: { get } })
+ *  - log() SILENTLY swallows insert errors / exceptions (never throws) and
+ *    routes them to logger.error
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+// Type-only import for annotations (the runtime value comes from the dynamic
+// import below, which TS sees as a value, not a type).
+import type { AuthEventType as AuthEventTypeT } from '../audit-logger';
+
+// Valid test UUIDs
+const USER_ID = '00000000-0000-0000-0000-000000000001';
+
+// Mock the logger - vi.hoisted so the spy exists before the service module is
+// imported (the service calls createLogger('auth:audit') at module load).
+const mockLoggerFns = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: vi.fn(() => mockLoggerFns),
+}));
+
+// Mock Supabase client. `insert` resolves to { error } directly (no chained
+// terminal in the service), so it returns a thenable-style result.
+const mockInsert = vi.fn();
+const mockFrom = vi.fn(() => ({ insert: mockInsert }));
+
+const mockSupabase = {
+  from: mockFrom,
+} as unknown as SupabaseClient;
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => mockSupabase,
+}));
+
+// Import after mocks are set up
+const { AuditLogger, AuthEventType } = await import('../audit-logger');
+
+/** Build a Request-like object backed by a vi.fn() header getter. */
+const makeRequest = (headers: Record<string, string>) => {
+  const get = vi.fn((name: string) => headers[name.toLowerCase()] ?? null);
+  return { headers: { get } } as unknown as Request;
+};
+
+/** Return the entry object passed to .insert() during the last log() call. */
+const lastInsertPayload = () => mockInsert.mock.calls.at(-1)?.[0];
+
+describe('AuditLogger', () => {
+  let auditLogger: InstanceType<typeof AuditLogger>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: insert succeeds.
+    mockInsert.mockResolvedValue({ error: null });
+    auditLogger = new AuditLogger();
+  });
+
+  describe('logSignUp', () => {
+    it('inserts a sign_up event into auth_audit_logs', async () => {
+      await auditLogger.logSignUp(USER_ID, 'user@example.com');
+
+      expect(mockFrom).toHaveBeenCalledWith('auth_audit_logs');
+      expect(lastInsertPayload()).toMatchObject({
+        user_id: USER_ID,
+        event_type: AuthEventType.SIGN_UP,
+        event_data: { email: 'user@example.com' },
+      });
+    });
+
+    it('attaches request info when a request is provided', async () => {
+      const request = makeRequest({
+        'x-forwarded-for': '203.0.113.5',
+        'user-agent': 'TestAgent/1.0',
+      });
+
+      await auditLogger.logSignUp(USER_ID, 'user@example.com', request);
+
+      expect(lastInsertPayload()).toMatchObject({
+        ip_address: '203.0.113.5',
+        user_agent: 'TestAgent/1.0',
+      });
+    });
+  });
+
+  describe('logSignIn', () => {
+    it('records sign_in_success when success is true', async () => {
+      await auditLogger.logSignIn(USER_ID, 'user@example.com', true);
+
+      expect(mockFrom).toHaveBeenCalledWith('auth_audit_logs');
+      expect(lastInsertPayload()).toMatchObject({
+        user_id: USER_ID,
+        event_type: AuthEventType.SIGN_IN_SUCCESS,
+        event_data: { email: 'user@example.com' },
+      });
+    });
+
+    it('records sign_in_failed with a null user_id when success is false', async () => {
+      await auditLogger.logSignIn(null, 'user@example.com', false);
+
+      expect(lastInsertPayload()).toMatchObject({
+        user_id: null,
+        event_type: AuthEventType.SIGN_IN_FAILED,
+        event_data: { email: 'user@example.com' },
+      });
+    });
+  });
+
+  describe('logSignOut', () => {
+    it('inserts a sign_out event', async () => {
+      await auditLogger.logSignOut(USER_ID);
+
+      expect(lastInsertPayload()).toMatchObject({
+        user_id: USER_ID,
+        event_type: AuthEventType.SIGN_OUT,
+      });
+    });
+
+    it('omits request info when no request is given', async () => {
+      await auditLogger.logSignOut(USER_ID);
+
+      const payload = lastInsertPayload();
+      expect(payload).not.toHaveProperty('ip_address');
+      expect(payload).not.toHaveProperty('user_agent');
+    });
+  });
+
+  describe('logPasswordChange', () => {
+    it('inserts a password_change event', async () => {
+      await auditLogger.logPasswordChange(USER_ID);
+
+      expect(lastInsertPayload()).toMatchObject({
+        user_id: USER_ID,
+        event_type: AuthEventType.PASSWORD_CHANGE,
+      });
+    });
+  });
+
+  describe('logPasswordResetRequest', () => {
+    it('inserts a password_reset_request event with a null user_id', async () => {
+      await auditLogger.logPasswordResetRequest('user@example.com');
+
+      expect(lastInsertPayload()).toMatchObject({
+        user_id: null,
+        event_type: AuthEventType.PASSWORD_RESET_REQUEST,
+        event_data: { email: 'user@example.com' },
+      });
+    });
+
+    it('captures ip + user agent from the request', async () => {
+      const request = makeRequest({
+        'x-real-ip': '198.51.100.7',
+        'user-agent': 'ResetAgent/2.0',
+      });
+
+      await auditLogger.logPasswordResetRequest('user@example.com', request);
+
+      expect(lastInsertPayload()).toMatchObject({
+        ip_address: '198.51.100.7',
+        user_agent: 'ResetAgent/2.0',
+      });
+    });
+  });
+
+  describe('logPasswordResetComplete', () => {
+    it('inserts a password_reset_complete event', async () => {
+      await auditLogger.logPasswordResetComplete(USER_ID);
+
+      expect(lastInsertPayload()).toMatchObject({
+        user_id: USER_ID,
+        event_type: AuthEventType.PASSWORD_RESET_COMPLETE,
+      });
+    });
+  });
+
+  describe('logEmailVerificationSent', () => {
+    it('inserts an email_verification_sent event with the email', async () => {
+      await auditLogger.logEmailVerificationSent(USER_ID, 'user@example.com');
+
+      expect(lastInsertPayload()).toMatchObject({
+        user_id: USER_ID,
+        event_type: AuthEventType.EMAIL_VERIFICATION_SENT,
+        event_data: { email: 'user@example.com' },
+      });
+    });
+  });
+
+  describe('logEmailVerificationComplete', () => {
+    it('inserts an email_verification_complete event', async () => {
+      await auditLogger.logEmailVerificationComplete(USER_ID);
+
+      expect(lastInsertPayload()).toMatchObject({
+        user_id: USER_ID,
+        event_type: AuthEventType.EMAIL_VERIFICATION_COMPLETE,
+      });
+    });
+  });
+
+  describe('logTokenRefresh', () => {
+    it('inserts a token_refresh event', async () => {
+      await auditLogger.logTokenRefresh(USER_ID);
+
+      expect(lastInsertPayload()).toMatchObject({
+        user_id: USER_ID,
+        event_type: AuthEventType.TOKEN_REFRESH,
+      });
+    });
+  });
+
+  describe('logAccountDelete', () => {
+    it('inserts an account_delete event', async () => {
+      await auditLogger.logAccountDelete(USER_ID);
+
+      expect(lastInsertPayload()).toMatchObject({
+        user_id: USER_ID,
+        event_type: AuthEventType.ACCOUNT_DELETE,
+      });
+    });
+  });
+
+  describe('stripCredentials', () => {
+    it('strips password/token/secret/key/credential fields from event_data', async () => {
+      // Reach into the private log() via a thin subclass to feed arbitrary
+      // event_data, exercising stripCredentials() on the real insert payload.
+      class TestableAuditLogger extends AuditLogger {
+        async logRaw(entry: {
+          user_id: string | null;
+          event_type: AuthEventTypeT;
+          event_data?: Record<string, unknown>;
+        }) {
+          // @ts-expect-error - exercising the private log() method under test
+          await this.log(entry);
+        }
+      }
+
+      const testable = new TestableAuditLogger();
+      await testable.logRaw({
+        user_id: USER_ID,
+        event_type: AuthEventType.SIGN_IN_SUCCESS,
+        event_data: {
+          email: 'user@example.com',
+          password: 'hunter2',
+          access_token: 'abc.def',
+          apiKey: 'sk-123',
+          mySecret: 'shh',
+          userCredential: 'nope',
+          safeField: 'kept',
+        },
+      });
+
+      const payload = lastInsertPayload();
+      expect(payload.event_data).toEqual({
+        email: 'user@example.com',
+        safeField: 'kept',
+      });
+      expect(payload.event_data).not.toHaveProperty('password');
+      expect(payload.event_data).not.toHaveProperty('access_token');
+      expect(payload.event_data).not.toHaveProperty('apiKey');
+      expect(payload.event_data).not.toHaveProperty('mySecret');
+      expect(payload.event_data).not.toHaveProperty('userCredential');
+    });
+
+    it('leaves undefined event_data as undefined', async () => {
+      await auditLogger.logSignOut(USER_ID);
+      expect(lastInsertPayload().event_data).toBeUndefined();
+    });
+  });
+
+  describe('extractRequestInfo', () => {
+    it('prefers x-forwarded-for over x-real-ip for ip_address', async () => {
+      const request = makeRequest({
+        'x-forwarded-for': '10.0.0.1',
+        'x-real-ip': '10.0.0.2',
+        'user-agent': 'UA/9',
+      });
+
+      await auditLogger.logSignOut(USER_ID, request);
+
+      expect(lastInsertPayload()).toMatchObject({
+        ip_address: '10.0.0.1',
+        user_agent: 'UA/9',
+      });
+    });
+
+    it('falls back to x-real-ip when x-forwarded-for is absent', async () => {
+      const request = makeRequest({
+        'x-real-ip': '10.0.0.2',
+        'user-agent': 'UA/9',
+      });
+
+      await auditLogger.logSignOut(USER_ID, request);
+
+      expect(lastInsertPayload()).toMatchObject({ ip_address: '10.0.0.2' });
+    });
+
+    it('sets ip_address to undefined when no ip headers are present', async () => {
+      const request = makeRequest({ 'user-agent': 'UA/9' });
+
+      await auditLogger.logSignOut(USER_ID, request);
+
+      const payload = lastInsertPayload();
+      expect(payload.ip_address).toBeUndefined();
+      expect(payload.user_agent).toBe('UA/9');
+    });
+  });
+
+  describe('error handling (log never throws)', () => {
+    it('swallows a Supabase insert error and routes it to logger.error', async () => {
+      mockInsert.mockResolvedValue({ error: { message: 'insert boom' } });
+
+      await expect(auditLogger.logSignOut(USER_ID)).resolves.toBeUndefined();
+
+      expect(mockLoggerFns.error).toHaveBeenCalledWith('Audit log failed', {
+        error: 'insert boom',
+      });
+    });
+
+    it('swallows a thrown insert exception and routes it to logger.error', async () => {
+      const boom = new Error('network down');
+      mockInsert.mockRejectedValue(boom);
+
+      await expect(auditLogger.logSignOut(USER_ID)).resolves.toBeUndefined();
+
+      expect(mockLoggerFns.error).toHaveBeenCalledWith('Audit log exception', {
+        error: boom,
+      });
+    });
+  });
+});

--- a/src/services/messaging/__tests__/group-key-service.test.ts
+++ b/src/services/messaging/__tests__/group-key-service.test.ts
@@ -1,0 +1,599 @@
+/**
+ * Unit Test: GroupKeyService
+ * Feature 010: Group Chats
+ *
+ * Tests GroupKeyService symmetric-key operations with a fully mocked
+ * Supabase client, messaging client, ECDH encryption service, key-management
+ * service, and Web Crypto (crypto.subtle / crypto.getRandomValues).
+ *
+ * No network and no real cryptography — crypto primitives return plausible
+ * fakes (exportKey -> 32-byte ArrayBuffer, encrypt/decrypt -> ArrayBuffer,
+ * generate/importKey -> stub CryptoKey). btoa/atob come from jsdom.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+// Valid test UUIDs
+const CURRENT_USER_ID = '00000000-0000-0000-0000-000000000001';
+const MEMBER_1_ID = '00000000-0000-0000-0000-000000000002';
+const MEMBER_2_ID = '00000000-0000-0000-0000-000000000003';
+const CONVERSATION_ID = '00000000-0000-0000-0000-000000000100';
+
+// Mock Supabase client (auth.getUser is what this service uses)
+const mockSupabase = {
+  from: vi.fn(),
+  auth: {
+    getUser: vi.fn(),
+  },
+} as unknown as SupabaseClient;
+
+// Mock messaging client (createMessagingClient(supabase).from(...))
+const mockMessagingFrom = vi.fn();
+const msgClient = { from: mockMessagingFrom };
+
+// Mock createClient
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => mockSupabase,
+}));
+
+// Mock createMessagingClient
+vi.mock('@/lib/supabase/messaging-client', () => ({
+  createMessagingClient: () => msgClient,
+}));
+
+// Mock ECDH encryption service
+vi.mock('@/lib/messaging/encryption', () => ({
+  encryptionService: {
+    deriveSharedSecret: vi.fn().mockResolvedValue({} as CryptoKey),
+  },
+}));
+
+// Mock key-management service
+vi.mock('@/services/messaging/key-service', () => ({
+  keyManagementService: {
+    getCurrentKeys: vi.fn(),
+    getUserPublicKey: vi.fn(),
+  },
+}));
+
+// Mock query builder (same helper shape as connection-service.test.ts)
+const createMockQueryBuilder = (data: any = null, error: any = null) => ({
+  select: vi.fn().mockReturnThis(),
+  insert: vi.fn().mockReturnThis(),
+  update: vi.fn().mockReturnThis(),
+  delete: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  neq: vi.fn().mockReturnThis(),
+  is: vi.fn().mockReturnThis(),
+  in: vi.fn().mockReturnThis(),
+  or: vi.fn().mockReturnThis(),
+  order: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockReturnThis(),
+  single: vi.fn().mockResolvedValue({ data, error }),
+  maybeSingle: vi.fn().mockResolvedValue({ data, error }),
+  then: vi.fn((resolve) => resolve({ data, error })),
+});
+
+// A fake JWK (member / sender public key shape)
+const TEST_PUBLIC_KEY: JsonWebKey = {
+  kty: 'EC',
+  crv: 'P-256',
+  x: 'test-x',
+  y: 'test-y',
+};
+
+// Stub CryptoKeys
+const STUB_GROUP_KEY = { type: 'secret' } as unknown as CryptoKey;
+const STUB_PRIVATE_KEY = { type: 'private' } as unknown as CryptoKey;
+
+// crypto.subtle / crypto.getRandomValues fakes
+const mockGenerateKey = vi.fn().mockResolvedValue(STUB_GROUP_KEY);
+const mockImportKey = vi.fn().mockResolvedValue({} as CryptoKey);
+const mockExportKey = vi.fn().mockResolvedValue(new ArrayBuffer(32));
+const mockEncrypt = vi.fn().mockResolvedValue(new ArrayBuffer(48));
+const mockDecrypt = vi.fn().mockResolvedValue(new ArrayBuffer(32));
+const mockGetRandomValues = vi.fn((arr: Uint8Array) => arr);
+
+// Import after mocks are set up
+const { GroupKeyService, groupKeyService } = await import(
+  '../group-key-service'
+);
+const { encryptionService } = await import('@/lib/messaging/encryption');
+const { keyManagementService } = await import(
+  '@/services/messaging/key-service'
+);
+
+describe('GroupKeyService', () => {
+  let service: InstanceType<typeof GroupKeyService>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Re-stub crypto each test (cleared by clearAllMocks impls retained)
+    vi.stubGlobal('crypto', {
+      subtle: {
+        generateKey: mockGenerateKey,
+        importKey: mockImportKey,
+        exportKey: mockExportKey,
+        encrypt: mockEncrypt,
+        decrypt: mockDecrypt,
+      },
+      getRandomValues: mockGetRandomValues,
+    });
+
+    // Restore default mock implementations (clearAllMocks wipes them)
+    mockGenerateKey.mockResolvedValue(STUB_GROUP_KEY);
+    mockImportKey.mockResolvedValue({} as CryptoKey);
+    mockExportKey.mockResolvedValue(new ArrayBuffer(32));
+    mockEncrypt.mockResolvedValue(new ArrayBuffer(48));
+    mockDecrypt.mockResolvedValue(new ArrayBuffer(32));
+    mockGetRandomValues.mockImplementation((arr: Uint8Array) => arr);
+
+    vi.mocked(encryptionService.deriveSharedSecret).mockResolvedValue(
+      {} as CryptoKey
+    );
+
+    // Default: authenticated user
+    vi.mocked(mockSupabase.auth.getUser).mockResolvedValue({
+      data: { user: { id: CURRENT_USER_ID } },
+      error: null,
+    } as any);
+
+    // Default: current user has keys
+    vi.mocked(keyManagementService.getCurrentKeys).mockReturnValue({
+      privateKey: STUB_PRIVATE_KEY,
+      publicKey: {} as CryptoKey,
+    } as any);
+
+    // Default: members have public keys
+    vi.mocked(keyManagementService.getUserPublicKey).mockResolvedValue(
+      TEST_PUBLIC_KEY
+    );
+
+    // Use a fresh instance per test so the in-memory cache is isolated
+    service = new GroupKeyService();
+  });
+
+  // ---------------------------------------------------------------------------
+  // generateGroupKey
+  // ---------------------------------------------------------------------------
+  describe('generateGroupKey', () => {
+    it('generates an AES-GCM-256 CryptoKey', async () => {
+      const key = await service.generateGroupKey();
+
+      expect(key).toBe(STUB_GROUP_KEY);
+      expect(mockGenerateKey).toHaveBeenCalledWith(
+        { name: 'AES-GCM', length: 256 },
+        true,
+        ['encrypt', 'decrypt']
+      );
+    });
+
+    it('throws GroupKeyError when generation fails', async () => {
+      mockGenerateKey.mockRejectedValueOnce(new Error('boom'));
+
+      await expect(service.generateGroupKey()).rejects.toThrow(
+        'Failed to generate group key'
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // encryptGroupKeyForMember
+  // ---------------------------------------------------------------------------
+  describe('encryptGroupKeyForMember', () => {
+    it('imports the member public key, derives a secret, and returns base64', async () => {
+      const result = await service.encryptGroupKeyForMember(
+        STUB_GROUP_KEY,
+        TEST_PUBLIC_KEY,
+        STUB_PRIVATE_KEY
+      );
+
+      expect(typeof result).toBe('string');
+      expect(result.length).toBeGreaterThan(0);
+      expect(mockImportKey).toHaveBeenCalledWith(
+        'jwk',
+        TEST_PUBLIC_KEY,
+        { name: 'ECDH', namedCurve: 'P-256' },
+        false,
+        []
+      );
+      expect(encryptionService.deriveSharedSecret).toHaveBeenCalled();
+      expect(mockEncrypt).toHaveBeenCalled();
+    });
+
+    it('throws GroupKeyError when encryption fails', async () => {
+      mockEncrypt.mockRejectedValueOnce(new Error('encrypt fail'));
+
+      await expect(
+        service.encryptGroupKeyForMember(
+          STUB_GROUP_KEY,
+          TEST_PUBLIC_KEY,
+          STUB_PRIVATE_KEY
+        )
+      ).rejects.toThrow('Failed to encrypt group key');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // decryptGroupKey
+  // ---------------------------------------------------------------------------
+  describe('decryptGroupKey', () => {
+    it('decodes base64, derives secret, decrypts, and imports the key', async () => {
+      // Round-trip: produce a real base64 string via the encrypt path first
+      const encrypted = await service.encryptGroupKeyForMember(
+        STUB_GROUP_KEY,
+        TEST_PUBLIC_KEY,
+        STUB_PRIVATE_KEY
+      );
+
+      const result = await service.decryptGroupKey(
+        encrypted,
+        TEST_PUBLIC_KEY,
+        STUB_PRIVATE_KEY
+      );
+
+      // importKeyBytes -> crypto.subtle.importKey('raw', ...) returns our stub
+      expect(result).toBeDefined();
+      expect(mockDecrypt).toHaveBeenCalled();
+      expect(encryptionService.deriveSharedSecret).toHaveBeenCalled();
+    });
+
+    it('throws GroupKeyError when decryption fails', async () => {
+      const encrypted = await service.encryptGroupKeyForMember(
+        STUB_GROUP_KEY,
+        TEST_PUBLIC_KEY,
+        STUB_PRIVATE_KEY
+      );
+      mockDecrypt.mockRejectedValueOnce(new Error('decrypt fail'));
+
+      await expect(
+        service.decryptGroupKey(encrypted, TEST_PUBLIC_KEY, STUB_PRIVATE_KEY)
+      ).rejects.toThrow('Failed to decrypt group key');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getGroupKeyForConversation
+  // ---------------------------------------------------------------------------
+  describe('getGroupKeyForConversation', () => {
+    it('returns the cached key on a cache hit (no DB / no auth call)', async () => {
+      // distributeGroupKey caches version 1 for current user
+      mockMessagingFrom.mockReturnValue(
+        createMockQueryBuilder([], null) as any
+      );
+      await service.distributeGroupKey(CONVERSATION_ID, [], 1);
+
+      vi.mocked(mockSupabase.auth.getUser).mockClear();
+      mockMessagingFrom.mockClear();
+
+      const key = await service.getGroupKeyForConversation(CONVERSATION_ID, 1);
+
+      expect(key).toBe(STUB_GROUP_KEY);
+      // Cache hit short-circuits before auth + DB
+      expect(mockSupabase.auth.getUser).not.toHaveBeenCalled();
+      expect(mockMessagingFrom).not.toHaveBeenCalled();
+    });
+
+    it('fetches + decrypts when not cached', async () => {
+      mockMessagingFrom.mockReturnValue(
+        createMockQueryBuilder(
+          { encrypted_key: 'ZmFrZQ==', created_by: MEMBER_1_ID },
+          null
+        ) as any
+      );
+
+      const key = await service.getGroupKeyForConversation(CONVERSATION_ID, 7);
+
+      expect(key).toBeDefined();
+      expect(mockMessagingFrom).toHaveBeenCalledWith('group_keys');
+      expect(keyManagementService.getUserPublicKey).toHaveBeenCalledWith(
+        MEMBER_1_ID
+      );
+      expect(mockDecrypt).toHaveBeenCalled();
+
+      // Second call should now be served from cache (no further DB hit)
+      mockMessagingFrom.mockClear();
+      const cached = await service.getGroupKeyForConversation(
+        CONVERSATION_ID,
+        7
+      );
+      expect(cached).toBe(key);
+      expect(mockMessagingFrom).not.toHaveBeenCalled();
+    });
+
+    it('throws AuthenticationError when not signed in', async () => {
+      vi.mocked(mockSupabase.auth.getUser).mockResolvedValue({
+        data: { user: null },
+        error: { message: 'Not authenticated' },
+      } as any);
+
+      await expect(
+        service.getGroupKeyForConversation(CONVERSATION_ID, 1)
+      ).rejects.toThrow('You must be signed in to access group keys');
+    });
+
+    it('throws GroupKeyError when the key row is not found (PGRST116)', async () => {
+      mockMessagingFrom.mockReturnValue(
+        createMockQueryBuilder(null, {
+          code: 'PGRST116',
+          message: 'no rows',
+        }) as any
+      );
+
+      await expect(
+        service.getGroupKeyForConversation(CONVERSATION_ID, 9)
+      ).rejects.toThrow('Group key not found for version 9');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // distributeGroupKey
+  // ---------------------------------------------------------------------------
+  describe('distributeGroupKey', () => {
+    const members = [
+      { id: 'm1', conversation_id: CONVERSATION_ID, user_id: MEMBER_1_ID },
+      { id: 'm2', conversation_id: CONVERSATION_ID, user_id: MEMBER_2_ID },
+    ] as any;
+
+    it('encrypts for each member and returns successful ids', async () => {
+      const builder = createMockQueryBuilder([], null);
+      mockMessagingFrom.mockReturnValue(builder as any);
+
+      const result = await service.distributeGroupKey(
+        CONVERSATION_ID,
+        members,
+        1
+      );
+
+      expect(result.successful).toEqual([MEMBER_1_ID, MEMBER_2_ID]);
+      expect(result.pending).toEqual([]);
+      expect(builder.insert).toHaveBeenCalled();
+      // Distributed key is cached for the current user
+      expect(service.getCachedKey(CONVERSATION_ID, 1)).toBe(STUB_GROUP_KEY);
+    });
+
+    it('marks members without a public key as pending', async () => {
+      vi.mocked(keyManagementService.getUserPublicKey).mockImplementation(
+        async (id: string) => (id === MEMBER_1_ID ? TEST_PUBLIC_KEY : null)
+      );
+      mockMessagingFrom.mockReturnValue(
+        createMockQueryBuilder([], null) as any
+      );
+
+      const result = await service.distributeGroupKey(
+        CONVERSATION_ID,
+        members,
+        1
+      );
+
+      expect(result.successful).toEqual([MEMBER_1_ID]);
+      expect(result.pending).toEqual([MEMBER_2_ID]);
+    });
+
+    it('throws AuthenticationError when not signed in', async () => {
+      vi.mocked(mockSupabase.auth.getUser).mockResolvedValue({
+        data: { user: null },
+        error: { message: 'Not authenticated' },
+      } as any);
+
+      await expect(
+        service.distributeGroupKey(CONVERSATION_ID, members, 1)
+      ).rejects.toThrow('You must be signed in to distribute group keys');
+    });
+
+    it('throws GroupKeyError when current user has no keys', async () => {
+      vi.mocked(keyManagementService.getCurrentKeys).mockReturnValue(null);
+
+      await expect(
+        service.distributeGroupKey(CONVERSATION_ID, members, 1)
+      ).rejects.toThrow('Encryption keys not available');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // rotateGroupKey
+  // ---------------------------------------------------------------------------
+  describe('rotateGroupKey', () => {
+    it('bumps the key version, distributes, and updates the conversation', async () => {
+      const activeMembers = [
+        { id: 'm1', conversation_id: CONVERSATION_ID, user_id: MEMBER_1_ID },
+      ];
+
+      mockMessagingFrom.mockImplementation((table: string) => {
+        if (table === 'conversations') {
+          return createMockQueryBuilder(
+            { current_key_version: 2 },
+            null
+          ) as any;
+        }
+        if (table === 'conversation_members') {
+          return createMockQueryBuilder(activeMembers, null) as any;
+        }
+        if (table === 'group_keys') {
+          return createMockQueryBuilder([], null) as any;
+        }
+        return createMockQueryBuilder(null, null) as any;
+      });
+
+      const newVersion = await service.rotateGroupKey(CONVERSATION_ID);
+
+      expect(newVersion).toBe(3);
+    });
+
+    it('throws AuthenticationError when not signed in', async () => {
+      vi.mocked(mockSupabase.auth.getUser).mockResolvedValue({
+        data: { user: null },
+        error: { message: 'Not authenticated' },
+      } as any);
+
+      await expect(service.rotateGroupKey(CONVERSATION_ID)).rejects.toThrow(
+        'You must be signed in to rotate group keys'
+      );
+    });
+
+    it('throws ConnectionError when the conversation lookup fails', async () => {
+      mockMessagingFrom.mockImplementation((table: string) => {
+        if (table === 'conversations') {
+          return createMockQueryBuilder(null, {
+            message: 'db down',
+          }) as any;
+        }
+        return createMockQueryBuilder(null, null) as any;
+      });
+
+      await expect(service.rotateGroupKey(CONVERSATION_ID)).rejects.toThrow(
+        'Failed to get conversation: db down'
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // retryKeyDistribution
+  // ---------------------------------------------------------------------------
+  describe('retryKeyDistribution', () => {
+    it('re-distributes to pending members and returns empty when all succeed', async () => {
+      // Seed a cached key so getGroupKeyForConversation is a cache hit
+      mockMessagingFrom.mockReturnValue(
+        createMockQueryBuilder([], null) as any
+      );
+      await service.distributeGroupKey(CONVERSATION_ID, [], 5);
+
+      mockMessagingFrom.mockImplementation((table: string) => {
+        if (table === 'conversations') {
+          return createMockQueryBuilder(
+            { current_key_version: 5 },
+            null
+          ) as any;
+        }
+        // group_keys / conversation_members inserts+updates succeed
+        return createMockQueryBuilder([], null) as any;
+      });
+
+      const stillPending = await service.retryKeyDistribution(CONVERSATION_ID, [
+        MEMBER_1_ID,
+      ]);
+
+      expect(stillPending).toEqual([]);
+    });
+
+    it('throws AuthenticationError when not signed in', async () => {
+      vi.mocked(mockSupabase.auth.getUser).mockResolvedValue({
+        data: { user: null },
+        error: { message: 'Not authenticated' },
+      } as any);
+
+      await expect(
+        service.retryKeyDistribution(CONVERSATION_ID, [MEMBER_1_ID])
+      ).rejects.toThrow('You must be signed in to retry key distribution');
+    });
+
+    it('throws GroupKeyError when current user has no keys', async () => {
+      mockMessagingFrom.mockImplementation((table: string) => {
+        if (table === 'conversations') {
+          return createMockQueryBuilder(
+            { current_key_version: 1 },
+            null
+          ) as any;
+        }
+        return createMockQueryBuilder([], null) as any;
+      });
+      vi.mocked(keyManagementService.getCurrentKeys).mockReturnValue(null);
+
+      await expect(
+        service.retryKeyDistribution(CONVERSATION_ID, [MEMBER_1_ID])
+      ).rejects.toThrow('Encryption keys not available');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // clearCache
+  // ---------------------------------------------------------------------------
+  describe('clearCache', () => {
+    it('empties the in-memory key cache', async () => {
+      mockMessagingFrom.mockReturnValue(
+        createMockQueryBuilder([], null) as any
+      );
+      await service.distributeGroupKey(CONVERSATION_ID, [], 1);
+      expect(service.getCachedKey(CONVERSATION_ID, 1)).toBe(STUB_GROUP_KEY);
+
+      service.clearCache();
+
+      expect(service.getCachedKey(CONVERSATION_ID, 1)).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getCachedKey
+  // ---------------------------------------------------------------------------
+  describe('getCachedKey', () => {
+    it('returns the cached key when present', async () => {
+      mockMessagingFrom.mockReturnValue(
+        createMockQueryBuilder([], null) as any
+      );
+      await service.distributeGroupKey(CONVERSATION_ID, [], 4);
+
+      expect(service.getCachedKey(CONVERSATION_ID, 4)).toBe(STUB_GROUP_KEY);
+    });
+
+    it('returns undefined when the key is not cached', () => {
+      expect(service.getCachedKey(CONVERSATION_ID, 999)).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // exportKeyBytes
+  // ---------------------------------------------------------------------------
+  describe('exportKeyBytes', () => {
+    it('exports raw key bytes via crypto.subtle.exportKey', async () => {
+      const bytes = await service.exportKeyBytes(STUB_GROUP_KEY);
+
+      expect(bytes).toBeInstanceOf(ArrayBuffer);
+      expect((bytes as ArrayBuffer).byteLength).toBe(32);
+      expect(mockExportKey).toHaveBeenCalledWith('raw', STUB_GROUP_KEY);
+    });
+
+    it('propagates errors from crypto.subtle.exportKey', async () => {
+      mockExportKey.mockRejectedValueOnce(new Error('not extractable'));
+
+      await expect(service.exportKeyBytes(STUB_GROUP_KEY)).rejects.toThrow(
+        'not extractable'
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // importKeyBytes
+  // ---------------------------------------------------------------------------
+  describe('importKeyBytes', () => {
+    it('imports an ArrayBuffer as an AES-GCM key', async () => {
+      const key = await service.importKeyBytes(new ArrayBuffer(32));
+
+      expect(key).toBeDefined();
+      expect(mockImportKey).toHaveBeenCalledWith(
+        'raw',
+        expect.any(Uint8Array),
+        { name: 'AES-GCM', length: 256 },
+        true,
+        ['encrypt', 'decrypt']
+      );
+    });
+
+    it('accepts a Uint8Array directly', async () => {
+      const key = await service.importKeyBytes(new Uint8Array(32));
+
+      expect(key).toBeDefined();
+      expect(mockImportKey).toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // singleton export
+  // ---------------------------------------------------------------------------
+  describe('groupKeyService singleton', () => {
+    it('is an instance of GroupKeyService', () => {
+      expect(groupKeyService).toBeInstanceOf(GroupKeyService);
+    });
+  });
+});

--- a/src/services/messaging/__tests__/key-service.test.ts
+++ b/src/services/messaging/__tests__/key-service.test.ts
@@ -1,0 +1,612 @@
+/**
+ * Unit Test: KeyManagementService
+ *
+ * Tests KeyManagementService methods with fully mocked dependencies:
+ * Supabase client, messaging client, encryption service, key-derivation
+ * service, IndexedDB (Dexie) table, and crypto.subtle. No network, no real
+ * crypto, no real IndexedDB — fast, deterministic unit tests.
+ *
+ * The service exports a class (KeyManagementService) plus a module-level
+ * singleton (keyManagementService). The singleton carries in-memory state
+ * (derivedKeys + publicKeyCache); we clear it in beforeEach via clearKeys()
+ * / clearPublicKeyCache() so tests don't pollute each other.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+// Valid test UUIDs
+const CURRENT_USER_ID = '00000000-0000-0000-0000-000000000001';
+const OTHER_USER_ID = '00000000-0000-0000-0000-000000000002';
+
+// ---------------------------------------------------------------------------
+// Supabase client mock (auth lives here)
+// ---------------------------------------------------------------------------
+const mockSupabase = {
+  from: vi.fn(),
+  auth: {
+    getUser: vi.fn(),
+    getSession: vi.fn(),
+  },
+} as unknown as SupabaseClient;
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => mockSupabase,
+}));
+
+// ---------------------------------------------------------------------------
+// Messaging client mock (all user_encryption_keys table access)
+// ---------------------------------------------------------------------------
+const mockMessagingFrom = vi.fn();
+
+vi.mock('@/lib/supabase/messaging-client', () => ({
+  createMessagingClient: () => ({
+    from: mockMessagingFrom,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Encryption service mock (IndexedDB private-key persistence)
+// ---------------------------------------------------------------------------
+const mockStorePrivateKey = vi.fn().mockResolvedValue(undefined);
+const mockGetPrivateKey = vi.fn().mockResolvedValue(null);
+
+vi.mock('@/lib/messaging/encryption', () => ({
+  encryptionService: {
+    storePrivateKey: (userId: string, key: CryptoKey) =>
+      mockStorePrivateKey(userId, key),
+    getPrivateKey: (userId: string) => mockGetPrivateKey(userId),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Key-derivation service mock (Argon2id + ECDH). The service instantiates
+// `new KeyDerivationService()`, so mock the class to return controllable
+// instance methods.
+// ---------------------------------------------------------------------------
+const mockGenerateSalt = vi.fn();
+const mockDeriveKeyPair = vi.fn();
+const mockVerifyPublicKey = vi.fn();
+
+vi.mock('@/lib/messaging/key-derivation', () => ({
+  KeyDerivationService: class {
+    generateSalt = mockGenerateSalt;
+    deriveKeyPair = mockDeriveKeyPair;
+    verifyPublicKey = mockVerifyPublicKey;
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Dexie database mock (clearKeys fire-and-forget IndexedDB wipe)
+// ---------------------------------------------------------------------------
+const mockPrivateKeysClear = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@/lib/messaging/database', () => ({
+  db: {
+    messaging_private_keys: {
+      clear: mockPrivateKeysClear,
+    },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// crypto.subtle.importKey stub (restoreKeysFromCache imports the public JWK)
+// ---------------------------------------------------------------------------
+const mockImportKey = vi.fn().mockResolvedValue({} as CryptoKey);
+vi.stubGlobal('crypto', {
+  subtle: {
+    importKey: mockImportKey,
+  },
+});
+
+// Mock query builder (matches connection-service.test.ts pattern)
+const createMockQueryBuilder = (data: any = null, error: any = null) => ({
+  select: vi.fn().mockReturnThis(),
+  insert: vi.fn().mockReturnThis(),
+  update: vi.fn().mockReturnThis(),
+  delete: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  neq: vi.fn().mockReturnThis(),
+  not: vi.fn().mockReturnThis(),
+  or: vi.fn().mockReturnThis(),
+  order: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockReturnThis(),
+  single: vi.fn().mockResolvedValue({ data, error }),
+  maybeSingle: vi.fn().mockResolvedValue({ data, error }),
+  then: vi.fn((resolve) => resolve({ data, error })),
+});
+
+// Reusable fake derived key pair + JWKs
+const PUBLIC_JWK: JsonWebKey = {
+  kty: 'EC',
+  crv: 'P-256',
+  x: 'derived-x',
+  y: 'derived-y',
+};
+const fakeKeyPair = {
+  privateKey: {} as CryptoKey,
+  publicKey: {} as CryptoKey,
+  publicKeyJwk: PUBLIC_JWK,
+  salt: 'base64salt',
+};
+
+// navigator.onLine helper
+const setOnline = (online: boolean) => {
+  Object.defineProperty(global, 'navigator', {
+    value: { onLine: online },
+    configurable: true,
+  });
+};
+
+// Import after mocks are set up
+const { keyManagementService, KeyManagementService } = await import(
+  '../key-service'
+);
+
+describe('KeyManagementService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Clear singleton in-memory state between tests.
+    keyManagementService.clearKeys();
+    keyManagementService.clearPublicKeyCache();
+
+    // Default: authenticated user via BOTH getSession + getUser.
+    vi.mocked(mockSupabase.auth.getSession).mockResolvedValue({
+      data: { session: { user: { id: CURRENT_USER_ID } } },
+      error: null,
+    } as any);
+    vi.mocked(mockSupabase.auth.getUser).mockResolvedValue({
+      data: { user: { id: CURRENT_USER_ID } },
+      error: null,
+    } as any);
+
+    // Default key-derivation behavior: succeed + verify true.
+    mockGenerateSalt.mockReturnValue(new Uint8Array([1, 2, 3, 4]));
+    mockDeriveKeyPair.mockResolvedValue(fakeKeyPair);
+    mockVerifyPublicKey.mockReturnValue(true);
+
+    // Default: persistence + restore stubs
+    mockStorePrivateKey.mockResolvedValue(undefined);
+    mockGetPrivateKey.mockResolvedValue(null);
+    mockImportKey.mockResolvedValue({} as CryptoKey);
+
+    // Default: online (so getUserPublicKey hits DB unless overridden).
+    setOnline(true);
+  });
+
+  describe('singleton export', () => {
+    it('exposes a singleton instance of KeyManagementService', () => {
+      expect(keyManagementService).toBeInstanceOf(KeyManagementService);
+    });
+  });
+
+  describe('initializeKeys', () => {
+    it('derives, uploads, and stores keys for a new user', async () => {
+      mockMessagingFrom.mockReturnValue(createMockQueryBuilder(null, null));
+
+      const result = await keyManagementService.initializeKeys('password');
+
+      expect(result).toEqual(fakeKeyPair);
+      expect(mockDeriveKeyPair).toHaveBeenCalled();
+      expect(mockStorePrivateKey).toHaveBeenCalledWith(
+        CURRENT_USER_ID,
+        fakeKeyPair.privateKey
+      );
+      expect(keyManagementService.getCurrentKeys()).toEqual(fakeKeyPair);
+    });
+
+    it('throws AuthenticationError when not signed in', async () => {
+      vi.mocked(mockSupabase.auth.getSession).mockResolvedValue({
+        data: { session: null },
+        error: { message: 'Not authenticated' },
+      } as any);
+
+      await expect(
+        keyManagementService.initializeKeys('password')
+      ).rejects.toThrow('You must be signed in to initialize encryption keys');
+    });
+
+    it('throws ConnectionError when the upload fails', async () => {
+      mockMessagingFrom.mockReturnValue(
+        createMockQueryBuilder(null, { message: 'insert failed' })
+      );
+
+      await expect(
+        keyManagementService.initializeKeys('password')
+      ).rejects.toThrow('Failed to upload public key: insert failed');
+    });
+  });
+
+  describe('deriveKeys', () => {
+    it('derives keys and verifies the stored public key (happy path)', async () => {
+      mockMessagingFrom.mockReturnValue(
+        createMockQueryBuilder(
+          { encryption_salt: 'YWJjZA==', public_key: PUBLIC_JWK },
+          null
+        )
+      );
+
+      const result = await keyManagementService.deriveKeys('password');
+
+      expect(result).toEqual(fakeKeyPair);
+      expect(mockVerifyPublicKey).toHaveBeenCalled();
+      expect(keyManagementService.getCurrentKeys()).toEqual(fakeKeyPair);
+    });
+
+    it('throws KeyMismatchError when password is wrong (verifyPublicKey false)', async () => {
+      mockVerifyPublicKey.mockReturnValue(false);
+      mockMessagingFrom.mockReturnValue(
+        createMockQueryBuilder(
+          { encryption_salt: 'YWJjZA==', public_key: PUBLIC_JWK },
+          null
+        )
+      );
+
+      await expect(keyManagementService.deriveKeys('wrong')).rejects.toThrow(
+        "Incorrect password. The encryption key doesn't match. Please try again."
+      );
+    });
+
+    it('throws AuthenticationError when not signed in', async () => {
+      vi.mocked(mockSupabase.auth.getSession).mockResolvedValue({
+        data: { session: null },
+        error: { message: 'Not authenticated' },
+      } as any);
+
+      await expect(keyManagementService.deriveKeys('password')).rejects.toThrow(
+        'You must be signed in to derive encryption keys'
+      );
+    });
+
+    it('throws KeyDerivationError when no salt exists for the user', async () => {
+      mockMessagingFrom.mockReturnValue(createMockQueryBuilder(null, null));
+
+      await expect(keyManagementService.deriveKeys('password')).rejects.toThrow(
+        'No salt found. User may need migration or initialization.'
+      );
+    });
+  });
+
+  describe('getCurrentKeys', () => {
+    it('returns null when no keys are in memory', () => {
+      expect(keyManagementService.getCurrentKeys()).toBeNull();
+    });
+
+    it('returns the in-memory key pair after initializeKeys', async () => {
+      mockMessagingFrom.mockReturnValue(createMockQueryBuilder(null, null));
+      await keyManagementService.initializeKeys('password');
+      expect(keyManagementService.getCurrentKeys()).toEqual(fakeKeyPair);
+    });
+  });
+
+  describe('restoreKeysFromCache', () => {
+    it('returns true immediately when keys already in memory', async () => {
+      mockMessagingFrom.mockReturnValue(createMockQueryBuilder(null, null));
+      await keyManagementService.initializeKeys('password');
+
+      const result =
+        await keyManagementService.restoreKeysFromCache(CURRENT_USER_ID);
+
+      expect(result).toBe(true);
+      // Should not have queried IndexedDB since memory was populated.
+      expect(mockGetPrivateKey).not.toHaveBeenCalled();
+    });
+
+    it('returns false when no userId is provided', async () => {
+      const result = await keyManagementService.restoreKeysFromCache();
+      expect(result).toBe(false);
+    });
+
+    it('returns false when no private key exists in IndexedDB', async () => {
+      mockGetPrivateKey.mockResolvedValue(null);
+
+      const result =
+        await keyManagementService.restoreKeysFromCache(CURRENT_USER_ID);
+
+      expect(result).toBe(false);
+    });
+
+    it('rebuilds the key pair from IndexedDB + Supabase (happy path)', async () => {
+      mockGetPrivateKey.mockResolvedValue({} as CryptoKey);
+      mockMessagingFrom.mockReturnValue(
+        createMockQueryBuilder(
+          { encryption_salt: 'base64salt', public_key: PUBLIC_JWK },
+          null
+        )
+      );
+
+      const result =
+        await keyManagementService.restoreKeysFromCache(CURRENT_USER_ID);
+
+      expect(result).toBe(true);
+      expect(mockImportKey).toHaveBeenCalled();
+      expect(keyManagementService.getCurrentKeys()).toMatchObject({
+        publicKeyJwk: PUBLIC_JWK,
+        salt: 'base64salt',
+      });
+    });
+
+    it('returns false when private key exists but Supabase has no public key/salt', async () => {
+      mockGetPrivateKey.mockResolvedValue({} as CryptoKey);
+      mockMessagingFrom.mockReturnValue(createMockQueryBuilder(null, null));
+
+      const result =
+        await keyManagementService.restoreKeysFromCache(CURRENT_USER_ID);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('clearKeys', () => {
+    it('clears in-memory keys and wipes the IndexedDB table', async () => {
+      mockMessagingFrom.mockReturnValue(createMockQueryBuilder(null, null));
+      await keyManagementService.initializeKeys('password');
+      expect(keyManagementService.getCurrentKeys()).not.toBeNull();
+
+      keyManagementService.clearKeys();
+
+      expect(keyManagementService.getCurrentKeys()).toBeNull();
+      expect(mockPrivateKeysClear).toHaveBeenCalled();
+    });
+  });
+
+  describe('needsMigration', () => {
+    it('returns false when user is not authenticated', async () => {
+      vi.mocked(mockSupabase.auth.getUser).mockResolvedValue({
+        data: { user: null },
+        error: { message: 'Not authenticated' },
+      } as any);
+
+      expect(await keyManagementService.needsMigration()).toBe(false);
+    });
+
+    it('returns false when user has at least one key with a valid salt', async () => {
+      // First query (valid keys with salt) returns a row.
+      mockMessagingFrom.mockReturnValue(
+        createMockQueryBuilder([{ id: 'k1' }], null)
+      );
+
+      expect(await keyManagementService.needsMigration()).toBe(false);
+    });
+
+    it('returns true when user has keys but none have a salt (legacy)', async () => {
+      // First query: no keys with salt. Second query: has some keys.
+      const noSaltKeys = createMockQueryBuilder([], null);
+      const anyKeys = createMockQueryBuilder([{ id: 'legacy' }], null);
+      let call = 0;
+      mockMessagingFrom.mockImplementation(() => {
+        call += 1;
+        return call === 1 ? noSaltKeys : anyKeys;
+      });
+
+      expect(await keyManagementService.needsMigration()).toBe(true);
+    });
+  });
+
+  describe('hasKeysForUser', () => {
+    it('returns true when a non-revoked key row exists', async () => {
+      mockMessagingFrom.mockReturnValue(
+        createMockQueryBuilder({ id: 'k1' }, null)
+      );
+
+      expect(await keyManagementService.hasKeysForUser(OTHER_USER_ID)).toBe(
+        true
+      );
+    });
+
+    it('returns false when no key row exists', async () => {
+      mockMessagingFrom.mockReturnValue(createMockQueryBuilder(null, null));
+
+      expect(await keyManagementService.hasKeysForUser(OTHER_USER_ID)).toBe(
+        false
+      );
+    });
+
+    it('throws ConnectionError on a non-PGRST116 database error', async () => {
+      mockMessagingFrom.mockReturnValue(
+        createMockQueryBuilder(null, { code: '500', message: 'boom' })
+      );
+
+      await expect(
+        keyManagementService.hasKeysForUser(OTHER_USER_ID)
+      ).rejects.toThrow('Failed to check encryption keys: boom');
+    });
+  });
+
+  describe('hasKeys', () => {
+    it('returns true when the authenticated user has a key row', async () => {
+      mockMessagingFrom.mockReturnValue(
+        createMockQueryBuilder({ id: 'k1' }, null)
+      );
+
+      expect(await keyManagementService.hasKeys()).toBe(true);
+    });
+
+    it('returns false when not authenticated', async () => {
+      vi.mocked(mockSupabase.auth.getSession).mockResolvedValue({
+        data: { session: null },
+        error: { message: 'Not authenticated' },
+      } as any);
+
+      expect(await keyManagementService.hasKeys()).toBe(false);
+    });
+
+    it('throws ConnectionError on a real database error', async () => {
+      mockMessagingFrom.mockReturnValue(
+        createMockQueryBuilder(null, { code: '500', message: 'db down' })
+      );
+
+      await expect(keyManagementService.hasKeys()).rejects.toThrow(
+        'Failed to check encryption keys: db down'
+      );
+    });
+  });
+
+  describe('hasValidKeys', () => {
+    it('returns true when keys are in memory (no DB hit)', async () => {
+      mockMessagingFrom.mockReturnValue(createMockQueryBuilder(null, null));
+      await keyManagementService.initializeKeys('password');
+
+      mockGetPrivateKey.mockClear();
+      expect(await keyManagementService.hasValidKeys()).toBe(true);
+      expect(mockGetPrivateKey).not.toHaveBeenCalled();
+    });
+
+    it('falls back to IndexedDB and returns true when a private key exists', async () => {
+      mockGetPrivateKey.mockResolvedValue({} as CryptoKey);
+
+      expect(await keyManagementService.hasValidKeys()).toBe(true);
+      expect(mockGetPrivateKey).toHaveBeenCalledWith(CURRENT_USER_ID);
+    });
+
+    it('throws AuthenticationError when not signed in and no memory keys', async () => {
+      vi.mocked(mockSupabase.auth.getUser).mockResolvedValue({
+        data: { user: null },
+        error: { message: 'Not authenticated' },
+      } as any);
+
+      await expect(keyManagementService.hasValidKeys()).rejects.toThrow(
+        'You must be signed in to check encryption keys'
+      );
+    });
+  });
+
+  describe('rotateKeys', () => {
+    it('revokes old keys, derives + uploads new ones (happy path)', async () => {
+      // Both update (revoke) and insert (upload) resolve with no error.
+      mockMessagingFrom.mockReturnValue(createMockQueryBuilder(null, null));
+
+      const result = await keyManagementService.rotateKeys('password');
+
+      expect(result).toBe(true);
+      expect(mockDeriveKeyPair).toHaveBeenCalled();
+      expect(mockStorePrivateKey).toHaveBeenCalledWith(
+        CURRENT_USER_ID,
+        fakeKeyPair.privateKey
+      );
+      expect(keyManagementService.getCurrentKeys()).toEqual(fakeKeyPair);
+    });
+
+    it('throws AuthenticationError when not signed in', async () => {
+      vi.mocked(mockSupabase.auth.getUser).mockResolvedValue({
+        data: { user: null },
+        error: { message: 'Not authenticated' },
+      } as any);
+
+      await expect(keyManagementService.rotateKeys('password')).rejects.toThrow(
+        'You must be signed in to rotate encryption keys'
+      );
+    });
+
+    it('throws ConnectionError when revoking old keys fails', async () => {
+      mockMessagingFrom.mockReturnValue(
+        createMockQueryBuilder(null, { message: 'revoke failed' })
+      );
+
+      await expect(keyManagementService.rotateKeys('password')).rejects.toThrow(
+        'Failed to revoke old keys: revoke failed'
+      );
+    });
+  });
+
+  describe('revokeKeys', () => {
+    it('marks all keys revoked when authenticated', async () => {
+      mockMessagingFrom.mockReturnValue(createMockQueryBuilder(null, null));
+
+      await expect(keyManagementService.revokeKeys()).resolves.toBeUndefined();
+    });
+
+    it('throws AuthenticationError when not signed in', async () => {
+      vi.mocked(mockSupabase.auth.getUser).mockResolvedValue({
+        data: { user: null },
+        error: { message: 'Not authenticated' },
+      } as any);
+
+      await expect(keyManagementService.revokeKeys()).rejects.toThrow(
+        'You must be signed in to revoke encryption keys'
+      );
+    });
+
+    it('throws ConnectionError when the revoke update fails', async () => {
+      mockMessagingFrom.mockReturnValue(
+        createMockQueryBuilder(null, { message: 'update failed' })
+      );
+
+      await expect(keyManagementService.revokeKeys()).rejects.toThrow(
+        'Failed to revoke keys: update failed'
+      );
+    });
+  });
+
+  describe('getUserPublicKey', () => {
+    it('fetches the public key from the database when online', async () => {
+      mockMessagingFrom.mockReturnValue(
+        createMockQueryBuilder({ public_key: PUBLIC_JWK }, null)
+      );
+
+      const result = await keyManagementService.getUserPublicKey(OTHER_USER_ID);
+
+      expect(result).toEqual(PUBLIC_JWK);
+    });
+
+    it('returns null when no key row exists (PGRST116)', async () => {
+      mockMessagingFrom.mockReturnValue(
+        createMockQueryBuilder(null, { code: 'PGRST116', message: 'no rows' })
+      );
+
+      expect(
+        await keyManagementService.getUserPublicKey(OTHER_USER_ID)
+      ).toBeNull();
+    });
+
+    it('throws ConnectionError on a real query error', async () => {
+      mockMessagingFrom.mockReturnValue(
+        createMockQueryBuilder(null, { code: '500', message: 'query boom' })
+      );
+
+      await expect(
+        keyManagementService.getUserPublicKey(OTHER_USER_ID)
+      ).rejects.toThrow('Failed to get user public key: query boom');
+    });
+
+    it('returns the cached key when offline (offline-cache branch)', async () => {
+      // First, populate the cache via an online fetch.
+      mockMessagingFrom.mockReturnValue(
+        createMockQueryBuilder({ public_key: PUBLIC_JWK }, null)
+      );
+      await keyManagementService.getUserPublicKey(OTHER_USER_ID);
+
+      // Now go offline and clear DB mocks — must serve from cache.
+      setOnline(false);
+      mockMessagingFrom.mockClear();
+
+      const result = await keyManagementService.getUserPublicKey(OTHER_USER_ID);
+
+      expect(result).toEqual(PUBLIC_JWK);
+      expect(mockMessagingFrom).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('clearPublicKeyCache', () => {
+    it('empties the cache so a later offline lookup misses', async () => {
+      // Populate cache online.
+      mockMessagingFrom.mockReturnValue(
+        createMockQueryBuilder({ public_key: PUBLIC_JWK }, null)
+      );
+      await keyManagementService.getUserPublicKey(OTHER_USER_ID);
+
+      keyManagementService.clearPublicKeyCache();
+
+      // Offline + no cache → falls through to DB query (which now finds nothing).
+      setOnline(false);
+      mockMessagingFrom.mockReturnValue(
+        createMockQueryBuilder(null, { code: 'PGRST116', message: 'no rows' })
+      );
+
+      expect(
+        await keyManagementService.getUserPublicKey(OTHER_USER_ID)
+      ).toBeNull();
+    });
+  });
+});

--- a/src/services/messaging/__tests__/message-service.test.ts
+++ b/src/services/messaging/__tests__/message-service.test.ts
@@ -1,0 +1,924 @@
+/**
+ * Unit Test: MessageService
+ *
+ * Tests every public method of MessageService (and the two standalone
+ * cache helpers) against fully mocked Supabase / messaging clients,
+ * encryption service, key-management service, offline queue, message
+ * cache, and crypto.subtle. No network, no IndexedDB, no real crypto.
+ *
+ * IMPORTANT — module-level cache pollution:
+ *   message-service.ts holds three module-level caches (conversationCache,
+ *   sharedSecretCache, cachedSenderPrivateKey). To keep tests independent,
+ *   every test starts from a fresh module instance: beforeEach calls
+ *   vi.resetModules() and re-imports the service so those module-level
+ *   Maps/refs are recreated empty per test.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Valid test UUIDs
+const CURRENT_USER_ID = '00000000-0000-0000-0000-000000000001';
+const OTHER_USER_ID = '00000000-0000-0000-0000-000000000002';
+const THIRD_USER_ID = '00000000-0000-0000-0000-000000000003';
+const CONVERSATION_ID = '00000000-0000-0000-0000-000000000100';
+const MESSAGE_ID = '00000000-0000-0000-0000-000000000200';
+
+// ---------------------------------------------------------------------------
+// Mock query builder — chainable; resolves the same {data,error,count} for
+// the terminal awaits the service uses (then / single / maybeSingle).
+// Mirrors the createMockQueryBuilder helper from connection-service.test.ts
+// but adds the messaging-specific terminals: in / is / lt / not.
+// ---------------------------------------------------------------------------
+const createMockQueryBuilder = (
+  data: any = null,
+  error: any = null,
+  count: number | null = null
+) => ({
+  select: vi.fn().mockReturnThis(),
+  insert: vi.fn().mockReturnThis(),
+  update: vi.fn().mockReturnThis(),
+  delete: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  neq: vi.fn().mockReturnThis(),
+  or: vi.fn().mockReturnThis(),
+  in: vi.fn().mockReturnThis(),
+  is: vi.fn().mockReturnThis(),
+  lt: vi.fn().mockReturnThis(),
+  order: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockReturnThis(),
+  single: vi.fn().mockResolvedValue({ data, error, count }),
+  maybeSingle: vi.fn().mockResolvedValue({ data, error, count }),
+  then: vi.fn((resolve) => resolve({ data, error, count })),
+});
+
+// Mock Supabase client (used only for auth.getSession in the service)
+const mockSupabase = {
+  from: vi.fn(),
+  auth: {
+    getUser: vi.fn(),
+    getSession: vi.fn(),
+  },
+} as any;
+
+// Mock messaging client (.from() returns query builders)
+const mockMsgFrom = vi.fn();
+const mockMsgClient = { from: mockMsgFrom } as any;
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => mockSupabase,
+}));
+
+vi.mock('@/lib/supabase/messaging-client', () => ({
+  createMessagingClient: () => mockMsgClient,
+}));
+
+// Mock encryption service
+vi.mock('@/lib/messaging/encryption', () => ({
+  encryptionService: {
+    deriveSharedSecret: vi.fn(),
+    encryptMessage: vi.fn(),
+    decryptMessage: vi.fn(),
+    getPrivateKey: vi.fn(),
+  },
+}));
+
+// Mock key-management service
+vi.mock('../key-service', () => ({
+  keyManagementService: {
+    getCurrentKeys: vi.fn(),
+    restoreKeysFromCache: vi.fn(),
+    getUserPublicKey: vi.fn(),
+  },
+}));
+
+// Mock offline queue service
+vi.mock('../offline-queue-service', () => ({
+  offlineQueueService: {
+    queueMessage: vi.fn(),
+  },
+}));
+
+// Mock message cache
+vi.mock('@/lib/messaging/cache', () => ({
+  cacheService: {
+    getCachedMessages: vi.fn(),
+    cacheMessages: vi.fn(),
+  },
+}));
+
+// Stubs we re-grab from the (mocked) modules each test
+let encryptionService: any;
+let keyManagementService: any;
+let offlineQueueService: any;
+let cacheService: any;
+
+// The service exports under test, re-imported per test after resetModules()
+let MessageService: any;
+let messageService: any;
+let isConversationCached: (id: string) => boolean;
+let cacheConversationData: (id: string, data: any) => Promise<void>;
+
+const DUMMY_PUBLIC_JWK: JsonWebKey = {
+  kty: 'EC',
+  crv: 'P-256',
+  x: 'test-x',
+  y: 'test-y',
+};
+
+/** Set navigator.onLine for the current test. */
+function setOnline(online: boolean) {
+  Object.defineProperty(global, 'navigator', {
+    value: { onLine: online },
+    configurable: true,
+  });
+}
+
+/** Default: authenticated session returning CURRENT_USER_ID. */
+function setAuthenticated() {
+  mockSupabase.auth.getSession.mockResolvedValue({
+    data: { session: { user: { id: CURRENT_USER_ID } } },
+    error: null,
+  });
+  mockSupabase.auth.getUser.mockResolvedValue({
+    data: { user: { id: CURRENT_USER_ID } },
+    error: null,
+  });
+}
+
+/** No session — every getSession attempt returns null. */
+function setUnauthenticated() {
+  mockSupabase.auth.getSession.mockResolvedValue({
+    data: { session: null },
+    error: { message: 'Not authenticated' },
+  });
+  mockSupabase.auth.getUser.mockResolvedValue({
+    data: { user: null },
+    error: { message: 'Not authenticated' },
+  });
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+
+  // Fresh module instances so module-level caches (conversationCache,
+  // sharedSecretCache, cachedSenderPrivateKey) start empty per test.
+  vi.resetModules();
+
+  const svcMod = await import('../message-service');
+  MessageService = svcMod.MessageService;
+  messageService = svcMod.messageService;
+  isConversationCached = svcMod.isConversationCached;
+  cacheConversationData = svcMod.cacheConversationData;
+
+  ({ encryptionService } = await import('@/lib/messaging/encryption'));
+  ({ keyManagementService } = await import('../key-service'));
+  ({ offlineQueueService } = await import('../offline-queue-service'));
+  ({ cacheService } = await import('@/lib/messaging/cache'));
+
+  // Sensible defaults
+  setOnline(true);
+  setAuthenticated();
+
+  keyManagementService.getCurrentKeys.mockReturnValue({
+    privateKey: { id: 'priv' } as unknown as CryptoKey,
+    publicKey: { id: 'pub' } as unknown as CryptoKey,
+  });
+  keyManagementService.restoreKeysFromCache.mockResolvedValue(true);
+  keyManagementService.getUserPublicKey.mockResolvedValue(DUMMY_PUBLIC_JWK);
+
+  encryptionService.deriveSharedSecret.mockResolvedValue(
+    {} as unknown as CryptoKey
+  );
+  encryptionService.encryptMessage.mockResolvedValue({
+    ciphertext: 'encrypted-content',
+    iv: 'test-iv',
+  });
+  encryptionService.decryptMessage.mockResolvedValue('decrypted text');
+  encryptionService.getPrivateKey.mockResolvedValue({} as unknown as CryptoKey);
+
+  offlineQueueService.queueMessage.mockResolvedValue(undefined);
+  cacheService.getCachedMessages.mockResolvedValue([]);
+  cacheService.cacheMessages.mockResolvedValue(0);
+
+  // crypto.subtle.importKey + randomUUID stub
+  vi.stubGlobal('crypto', {
+    subtle: { importKey: vi.fn().mockResolvedValue({}) },
+    randomUUID: vi.fn(() => '11111111-1111-1111-1111-111111111111'),
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('MessageService', () => {
+  describe('module exports', () => {
+    it('exports a MessageService class and a singleton instance', () => {
+      expect(typeof MessageService).toBe('function');
+      expect(messageService).toBeInstanceOf(MessageService);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // sendMessage
+  // -----------------------------------------------------------------------
+  describe('sendMessage', () => {
+    const baseConv = {
+      participant_1_id: CURRENT_USER_ID,
+      participant_2_id: OTHER_USER_ID,
+      is_group: false,
+    };
+
+    it('sends a message successfully when online (happy path)', async () => {
+      // conversations lookup -> messages seq lookup -> insert -> conv update
+      mockMsgFrom.mockImplementation((table: string) => {
+        if (table === 'conversations') {
+          return createMockQueryBuilder(baseConv, null);
+        }
+        if (table === 'messages') {
+          // First a select (seq number) then an insert().select().single()
+          const builder = createMockQueryBuilder(
+            { id: MESSAGE_ID, sequence_number: 1 },
+            null
+          );
+          // maybeSingle returns the "last message" seq number lookup
+          builder.maybeSingle = vi
+            .fn()
+            .mockResolvedValue({ data: { sequence_number: 5 }, error: null });
+          // insert().select().single() returns the inserted row
+          builder.single = vi.fn().mockResolvedValue({
+            data: { id: MESSAGE_ID, sequence_number: 6 },
+            error: null,
+          });
+          return builder;
+        }
+        return createMockQueryBuilder(null, null);
+      });
+
+      const result = await messageService.sendMessage({
+        conversation_id: CONVERSATION_ID,
+        content: 'hello world',
+      });
+
+      expect(result.queued).toBe(false);
+      expect(result.message).toEqual({ id: MESSAGE_ID, sequence_number: 6 });
+      expect(encryptionService.encryptMessage).toHaveBeenCalledWith(
+        'hello world',
+        expect.anything()
+      );
+    });
+
+    it('rejects empty content (min length validation)', async () => {
+      await expect(
+        messageService.sendMessage({
+          conversation_id: CONVERSATION_ID,
+          content: '   ',
+        })
+      ).rejects.toThrow('Message cannot be empty');
+    });
+
+    it('rejects content over MAX_LENGTH', async () => {
+      await expect(
+        messageService.sendMessage({
+          conversation_id: CONVERSATION_ID,
+          content: 'a'.repeat(10001),
+        })
+      ).rejects.toThrow('cannot exceed');
+    });
+
+    it('throws AuthenticationError when not signed in (after retries)', async () => {
+      setUnauthenticated();
+      const promise = messageService.sendMessage({
+        conversation_id: CONVERSATION_ID,
+        content: 'hi there',
+      });
+      // Attach the rejection assertion BEFORE draining timers so the promise
+      // is never momentarily unhandled (avoids Vitest unhandled-rejection
+      // false positives), then drain the 2 x 500ms retry sleeps.
+      const assertion = expect(promise).rejects.toThrow(
+        'You must be signed in to send messages'
+      );
+      await vi.runAllTimersAsync();
+      await assertion;
+    });
+
+    it('succeeds on a later getSession retry (session-retry)', async () => {
+      // First two attempts null, third returns a session
+      mockSupabase.auth.getSession
+        .mockResolvedValueOnce({ data: { session: null }, error: null })
+        .mockResolvedValueOnce({ data: { session: null }, error: null })
+        .mockResolvedValue({
+          data: { session: { user: { id: CURRENT_USER_ID } } },
+          error: null,
+        });
+
+      mockMsgFrom.mockImplementation((table: string) => {
+        if (table === 'conversations') {
+          return createMockQueryBuilder(baseConv, null);
+        }
+        if (table === 'messages') {
+          const builder = createMockQueryBuilder(null, null);
+          builder.maybeSingle = vi
+            .fn()
+            .mockResolvedValue({ data: null, error: null });
+          builder.single = vi
+            .fn()
+            .mockResolvedValue({ data: { id: MESSAGE_ID }, error: null });
+          return builder;
+        }
+        return createMockQueryBuilder(null, null);
+      });
+
+      const promise = messageService.sendMessage({
+        conversation_id: CONVERSATION_ID,
+        content: 'retry me',
+      });
+      await vi.runAllTimersAsync();
+      const result = await promise;
+      expect(result.queued).toBe(false);
+      // Two retries means at least 3 getSession calls
+      expect(
+        mockSupabase.auth.getSession.mock.calls.length
+      ).toBeGreaterThanOrEqual(3);
+    });
+
+    it('queues the message when offline', async () => {
+      setOnline(false);
+      mockMsgFrom.mockImplementation((table: string) => {
+        if (table === 'conversations') {
+          return createMockQueryBuilder(baseConv, null);
+        }
+        return createMockQueryBuilder(null, null);
+      });
+
+      const result = await messageService.sendMessage({
+        conversation_id: CONVERSATION_ID,
+        content: 'offline message',
+      });
+
+      expect(result.queued).toBe(true);
+      expect(offlineQueueService.queueMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          conversation_id: CONVERSATION_ID,
+          sender_id: CURRENT_USER_ID,
+          content: 'offline message',
+          encrypted_content: 'encrypted-content',
+          initialization_vector: 'test-iv',
+        })
+      );
+    });
+
+    it('throws EncryptionLockedError when keys cannot be restored', async () => {
+      keyManagementService.getCurrentKeys.mockReturnValue(null);
+      keyManagementService.restoreKeysFromCache.mockResolvedValue(false);
+
+      await expect(
+        messageService.sendMessage({
+          conversation_id: CONVERSATION_ID,
+          content: 'no keys',
+        })
+      ).rejects.toThrow('encryption keys are not available');
+    });
+
+    it('throws ValidationError for group conversations', async () => {
+      mockMsgFrom.mockImplementation((table: string) => {
+        if (table === 'conversations') {
+          return createMockQueryBuilder({ ...baseConv, is_group: true }, null);
+        }
+        return createMockQueryBuilder(null, null);
+      });
+
+      await expect(
+        messageService.sendMessage({
+          conversation_id: CONVERSATION_ID,
+          content: 'group msg',
+        })
+      ).rejects.toThrow('Group message encryption not yet implemented');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getMessageHistory
+  // -----------------------------------------------------------------------
+  describe('getMessageHistory', () => {
+    const conv = {
+      participant_1_id: CURRENT_USER_ID,
+      participant_2_id: OTHER_USER_ID,
+      is_group: false,
+    };
+
+    const messageRow = {
+      id: MESSAGE_ID,
+      conversation_id: CONVERSATION_ID,
+      sender_id: OTHER_USER_ID,
+      encrypted_content: 'enc',
+      initialization_vector: 'iv',
+      sequence_number: 1,
+      deleted: false,
+      edited: false,
+      edited_at: null,
+      delivered_at: null,
+      read_at: null,
+      created_at: '2025-01-01T00:00:00Z',
+    };
+
+    function wireHistory(rows: any[], decryptImpl?: () => any) {
+      mockMsgFrom.mockImplementation((table: string) => {
+        if (table === 'messages') {
+          return createMockQueryBuilder(rows, null);
+        }
+        if (table === 'conversations') {
+          return createMockQueryBuilder(conv, null);
+        }
+        if (table === 'user_profiles') {
+          return createMockQueryBuilder(
+            [
+              { id: CURRENT_USER_ID, username: 'me', display_name: 'Me' },
+              { id: OTHER_USER_ID, username: 'them', display_name: 'Them' },
+            ],
+            null
+          );
+        }
+        return createMockQueryBuilder(null, null);
+      });
+      if (decryptImpl) {
+        encryptionService.decryptMessage.mockImplementation(decryptImpl);
+      }
+    }
+
+    it('fetches and decrypts messages (happy path)', async () => {
+      wireHistory([messageRow], () => Promise.resolve('hello!'));
+
+      const result = await messageService.getMessageHistory(CONVERSATION_ID);
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].content).toBe('hello!');
+      expect(result.messages[0].id).toBe(MESSAGE_ID);
+      expect(cacheService.cacheMessages).toHaveBeenCalled();
+    });
+
+    it('returns a decryption placeholder when decrypt fails', async () => {
+      wireHistory([messageRow], () => Promise.reject(new Error('bad key')));
+
+      const result = await messageService.getMessageHistory(CONVERSATION_ID);
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].decryptionError).toBe(true);
+      expect(result.messages[0].content).toBe('Encrypted with previous keys');
+    });
+
+    it('falls back to IndexedDB cache when offline', async () => {
+      setOnline(false);
+      cacheService.getCachedMessages.mockResolvedValue([messageRow]);
+      mockMsgFrom.mockImplementation((table: string) => {
+        if (table === 'conversations') {
+          return createMockQueryBuilder(conv, null);
+        }
+        if (table === 'user_profiles') {
+          return createMockQueryBuilder([], null);
+        }
+        return createMockQueryBuilder(null, null);
+      });
+      encryptionService.decryptMessage.mockResolvedValue('cached text');
+
+      const result = await messageService.getMessageHistory(CONVERSATION_ID);
+
+      expect(cacheService.getCachedMessages).toHaveBeenCalledWith(
+        CONVERSATION_ID,
+        50
+      );
+      expect(result.messages[0].content).toBe('cached text');
+    });
+
+    it('returns empty when offline with no cache', async () => {
+      setOnline(false);
+      cacheService.getCachedMessages.mockResolvedValue([]);
+
+      const result = await messageService.getMessageHistory(CONVERSATION_ID);
+
+      expect(result).toEqual({ messages: [], has_more: false, cursor: null });
+    });
+
+    it('throws AuthenticationError when not signed in', async () => {
+      setUnauthenticated();
+      const promise = messageService.getMessageHistory(CONVERSATION_ID);
+      // Attach assertion before draining timers (see sendMessage auth test).
+      const assertion = expect(promise).rejects.toThrow(
+        'You must be signed in to view messages'
+      );
+      await vi.runAllTimersAsync();
+      await assertion;
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // markAsRead
+  // -----------------------------------------------------------------------
+  describe('markAsRead', () => {
+    it('updates read_at for given message ids (happy path)', async () => {
+      const builder = createMockQueryBuilder(null, null, 2);
+      mockMsgFrom.mockReturnValue(builder);
+
+      await messageService.markAsRead([MESSAGE_ID]);
+
+      expect(mockMsgFrom).toHaveBeenCalledWith('messages');
+      expect(builder.update).toHaveBeenCalledWith(
+        expect.objectContaining({ read_at: expect.any(String) })
+      );
+    });
+
+    it('returns early (no DB call) when given an empty array', async () => {
+      await messageService.markAsRead([]);
+      expect(mockMsgFrom).not.toHaveBeenCalled();
+    });
+
+    it('throws ConnectionError when the update fails', async () => {
+      const builder = createMockQueryBuilder(null, {
+        message: 'db down',
+      });
+      mockMsgFrom.mockReturnValue(builder);
+
+      await expect(messageService.markAsRead([MESSAGE_ID])).rejects.toThrow(
+        'Failed to mark messages as read: db down'
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // markAsDelivered
+  // -----------------------------------------------------------------------
+  describe('markAsDelivered', () => {
+    it('updates delivered_at for given message ids (happy path)', async () => {
+      const builder = createMockQueryBuilder(null, null, 1);
+      mockMsgFrom.mockReturnValue(builder);
+
+      await messageService.markAsDelivered([MESSAGE_ID]);
+
+      expect(builder.update).toHaveBeenCalledWith(
+        expect.objectContaining({ delivered_at: expect.any(String) })
+      );
+    });
+
+    it('returns early when given an empty array', async () => {
+      await messageService.markAsDelivered([]);
+      expect(mockMsgFrom).not.toHaveBeenCalled();
+    });
+
+    it('swallows DB errors silently (never throws)', async () => {
+      const builder = createMockQueryBuilder(null, { message: 'boom' });
+      mockMsgFrom.mockReturnValue(builder);
+
+      // Should resolve, not reject — delivery receipts never break the UI
+      await expect(
+        messageService.markAsDelivered([MESSAGE_ID])
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // editMessage
+  // -----------------------------------------------------------------------
+  describe('editMessage', () => {
+    const recentMessage = (overrides: any = {}) => ({
+      id: MESSAGE_ID,
+      conversation_id: CONVERSATION_ID,
+      sender_id: CURRENT_USER_ID,
+      created_at: new Date().toISOString(),
+      deleted: false,
+      ...overrides,
+    });
+
+    const conv = {
+      participant_1_id: CURRENT_USER_ID,
+      participant_2_id: OTHER_USER_ID,
+      is_group: false,
+    };
+
+    function wireEdit(messageData: any, updateError: any = null) {
+      mockMsgFrom.mockImplementation((table: string) => {
+        if (table === 'messages') {
+          const builder = createMockQueryBuilder(messageData, null);
+          // fetch uses .single(); update uses terminal then() -> updateError
+          builder.then = vi.fn((resolve) =>
+            resolve({ data: null, error: updateError })
+          );
+          return builder;
+        }
+        if (table === 'conversations') {
+          return createMockQueryBuilder(conv, null);
+        }
+        return createMockQueryBuilder(null, null);
+      });
+    }
+
+    it('re-encrypts and updates within the window (happy path)', async () => {
+      wireEdit(recentMessage());
+
+      await messageService.editMessage({
+        message_id: MESSAGE_ID,
+        new_content: 'edited text',
+      });
+
+      expect(encryptionService.encryptMessage).toHaveBeenCalledWith(
+        'edited text',
+        expect.anything()
+      );
+    });
+
+    it('rejects empty new content', async () => {
+      await expect(
+        messageService.editMessage({ message_id: MESSAGE_ID, new_content: ' ' })
+      ).rejects.toThrow('Message cannot be empty');
+    });
+
+    it('throws when the user does not own the message (ownership)', async () => {
+      wireEdit(recentMessage({ sender_id: THIRD_USER_ID }));
+
+      await expect(
+        messageService.editMessage({
+          message_id: MESSAGE_ID,
+          new_content: 'nope',
+        })
+      ).rejects.toThrow('You can only edit your own messages');
+    });
+
+    it('throws when outside the 15-minute edit window', async () => {
+      const old = new Date(Date.now() - 20 * 60 * 1000).toISOString();
+      wireEdit(recentMessage({ created_at: old }));
+
+      await expect(
+        messageService.editMessage({
+          message_id: MESSAGE_ID,
+          new_content: 'too late',
+        })
+      ).rejects.toThrow('can only be edited within 15 minutes');
+    });
+
+    it('throws when the message is not found', async () => {
+      mockMsgFrom.mockImplementation((table: string) => {
+        if (table === 'messages') {
+          return createMockQueryBuilder(null, { message: 'not found' });
+        }
+        return createMockQueryBuilder(null, null);
+      });
+
+      await expect(
+        messageService.editMessage({
+          message_id: MESSAGE_ID,
+          new_content: 'ghost',
+        })
+      ).rejects.toThrow('Message not found');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // deleteMessage
+  // -----------------------------------------------------------------------
+  describe('deleteMessage', () => {
+    const recentMessage = (overrides: any = {}) => ({
+      id: MESSAGE_ID,
+      conversation_id: CONVERSATION_ID,
+      sender_id: CURRENT_USER_ID,
+      created_at: new Date().toISOString(),
+      deleted: false,
+      ...overrides,
+    });
+
+    function wireDelete(messageData: any, updateError: any = null) {
+      const builder = createMockQueryBuilder(messageData, null);
+      // soft-delete update is a terminal await on the builder (then())
+      builder.then = vi.fn((resolve) =>
+        resolve({ data: null, error: updateError })
+      );
+      mockMsgFrom.mockReturnValue(builder);
+      return builder;
+    }
+
+    it('soft-deletes (sets deleted:true) within the window (happy path)', async () => {
+      const builder = wireDelete(recentMessage());
+
+      await messageService.deleteMessage(MESSAGE_ID);
+
+      expect(builder.update).toHaveBeenCalledWith({ deleted: true });
+    });
+
+    it('throws when the user does not own the message (ownership)', async () => {
+      wireDelete(recentMessage({ sender_id: THIRD_USER_ID }));
+
+      await expect(messageService.deleteMessage(MESSAGE_ID)).rejects.toThrow(
+        'You can only delete your own messages'
+      );
+    });
+
+    it('throws when the message is already deleted', async () => {
+      wireDelete(recentMessage({ deleted: true }));
+
+      await expect(messageService.deleteMessage(MESSAGE_ID)).rejects.toThrow(
+        'Message is already deleted'
+      );
+    });
+
+    it('throws when outside the 15-minute delete window', async () => {
+      const old = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+      wireDelete(recentMessage({ created_at: old }));
+
+      await expect(messageService.deleteMessage(MESSAGE_ID)).rejects.toThrow(
+        'can only be deleted within 15 minutes'
+      );
+    });
+
+    it('throws ConnectionError when the soft-delete update fails', async () => {
+      wireDelete(recentMessage(), { message: 'update failed' });
+
+      await expect(messageService.deleteMessage(MESSAGE_ID)).rejects.toThrow(
+        'Failed to delete message: update failed'
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // archiveConversation
+  // -----------------------------------------------------------------------
+  describe('archiveConversation', () => {
+    function wireArchive(conv: any, updateError: any = null) {
+      const builder = createMockQueryBuilder(conv, null);
+      // update().eq().select() resolves via then()
+      builder.then = vi.fn((resolve) =>
+        resolve({ data: [{}], error: updateError })
+      );
+      mockMsgFrom.mockReturnValue(builder);
+      return builder;
+    }
+
+    it('archives as participant_1 (happy path)', async () => {
+      const builder = wireArchive({
+        participant_1_id: CURRENT_USER_ID,
+        participant_2_id: OTHER_USER_ID,
+        is_group: false,
+      });
+
+      await messageService.archiveConversation(CONVERSATION_ID);
+
+      expect(builder.update).toHaveBeenCalledWith({
+        archived_by_participant_1: true,
+      });
+    });
+
+    it('archives as participant_2', async () => {
+      const builder = wireArchive({
+        participant_1_id: OTHER_USER_ID,
+        participant_2_id: CURRENT_USER_ID,
+        is_group: false,
+      });
+
+      await messageService.archiveConversation(CONVERSATION_ID);
+
+      expect(builder.update).toHaveBeenCalledWith({
+        archived_by_participant_2: true,
+      });
+    });
+
+    it('throws when the user is not a participant', async () => {
+      wireArchive({
+        participant_1_id: OTHER_USER_ID,
+        participant_2_id: THIRD_USER_ID,
+        is_group: false,
+      });
+
+      await expect(
+        messageService.archiveConversation(CONVERSATION_ID)
+      ).rejects.toThrow('You are not a participant in this conversation');
+    });
+
+    it('throws when the conversation is not found', async () => {
+      mockMsgFrom.mockReturnValue(
+        createMockQueryBuilder(null, { message: 'missing' })
+      );
+
+      await expect(
+        messageService.archiveConversation(CONVERSATION_ID)
+      ).rejects.toThrow('Conversation not found');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // unarchiveConversation
+  // -----------------------------------------------------------------------
+  describe('unarchiveConversation', () => {
+    function wireUnarchive(conv: any, updateError: any = null) {
+      const builder = createMockQueryBuilder(conv, null);
+      builder.then = vi.fn((resolve) =>
+        resolve({ data: null, error: updateError })
+      );
+      mockMsgFrom.mockReturnValue(builder);
+      return builder;
+    }
+
+    it('unarchives as participant_1 (happy path)', async () => {
+      const builder = wireUnarchive({
+        participant_1_id: CURRENT_USER_ID,
+        participant_2_id: OTHER_USER_ID,
+        is_group: false,
+      });
+
+      await messageService.unarchiveConversation(CONVERSATION_ID);
+
+      expect(builder.update).toHaveBeenCalledWith({
+        archived_by_participant_1: false,
+      });
+    });
+
+    it('throws ConnectionError when the update fails', async () => {
+      wireUnarchive(
+        {
+          participant_1_id: CURRENT_USER_ID,
+          participant_2_id: OTHER_USER_ID,
+          is_group: false,
+        },
+        { message: 'nope' }
+      );
+
+      await expect(
+        messageService.unarchiveConversation(CONVERSATION_ID)
+      ).rejects.toThrow('Failed to unarchive conversation: nope');
+    });
+
+    it('throws for group conversations', async () => {
+      wireUnarchive({
+        participant_1_id: CURRENT_USER_ID,
+        participant_2_id: OTHER_USER_ID,
+        is_group: true,
+      });
+
+      await expect(
+        messageService.unarchiveConversation(CONVERSATION_ID)
+      ).rejects.toThrow('Group conversation unarchiving not yet implemented');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // isConversationCached + cacheConversationData (standalone helpers)
+  // -----------------------------------------------------------------------
+  describe('isConversationCached / cacheConversationData', () => {
+    it('reports false before caching and true after', async () => {
+      expect(isConversationCached(CONVERSATION_ID)).toBe(false);
+
+      await cacheConversationData(CONVERSATION_ID, {
+        participant_1_id: CURRENT_USER_ID,
+        participant_2_id: OTHER_USER_ID,
+        is_group: false,
+      });
+
+      expect(isConversationCached(CONVERSATION_ID)).toBe(true);
+    });
+
+    it('pre-fetches the recipient public key for 1-to-1 conversations', async () => {
+      await cacheConversationData(CONVERSATION_ID, {
+        participant_1_id: CURRENT_USER_ID,
+        participant_2_id: OTHER_USER_ID,
+        is_group: false,
+      });
+
+      // recipient is the OTHER participant
+      expect(keyManagementService.getUserPublicKey).toHaveBeenCalledWith(
+        OTHER_USER_ID
+      );
+    });
+
+    it('does not pre-fetch a public key for group conversations', async () => {
+      await cacheConversationData(CONVERSATION_ID, {
+        participant_1_id: CURRENT_USER_ID,
+        participant_2_id: OTHER_USER_ID,
+        is_group: true,
+      });
+
+      expect(keyManagementService.getUserPublicKey).not.toHaveBeenCalled();
+      expect(isConversationCached(CONVERSATION_ID)).toBe(true);
+    });
+
+    it('swallows public-key prefetch errors (non-fatal)', async () => {
+      keyManagementService.getUserPublicKey.mockRejectedValue(
+        new Error('network')
+      );
+
+      await expect(
+        cacheConversationData(CONVERSATION_ID, {
+          participant_1_id: CURRENT_USER_ID,
+          participant_2_id: OTHER_USER_ID,
+          is_group: false,
+        })
+      ).resolves.toBeUndefined();
+
+      // Cache is still populated even though prefetch threw
+      expect(isConversationCached(CONVERSATION_ID)).toBe(true);
+    });
+
+    it('module-level cache is reset between tests (isolation check)', () => {
+      // If resetModules() were not wired into beforeEach, the entry written
+      // by the first test in this block would still be present here.
+      expect(isConversationCached(CONVERSATION_ID)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Closes #41.

## Why

4 of 8 messaging/auth services had **zero** unit-test coverage — including the largest and most security-critical path, `message-service.ts` (1465 LOC: encryption, send, retrieve, edit, delete). Bugs in these paths have caused multiple reverts. Per the `035` spec (NFR-001: line coverage for all 4).

## What

130 new unit tests across 4 files, following the existing `__tests__/` conventions (vitest/jsdom, mocked Supabase query-builder + messaging-client + encryption + `crypto.subtle` + `navigator.onLine` + fake-indexeddb):

| Service | LOC | Tests | Coverage |
|---|---|---|---|
| `message-service.ts` | 1465 | **42** | send (online / offline-queue / validation / session-retry), getMessageHistory (decrypt + decrypt-fail placeholder + offline cache), mark read/delivered, edit/delete (ownership + 15-min window), archive/unarchive |
| `key-service.ts` | 804 | **39** | initialize/derive (KeyMismatchError on wrong password), restore-from-cache, rotate/revoke, hasKeys*, getUserPublicKey (online + offline-cache) |
| `group-key-service.ts` | 818 | **28** | generate/encrypt/decrypt group key, distribute/rotate/retry, LRU cache, export/import key bytes |
| `audit-logger.ts` | 223 | **21** | all 10 `log*` events, `stripCredentials` (password/token/secret/key/credential), `extractRequestInfo`, silent-failure `log()` |

**No service source was modified** — all 4 were verified testable as-is (so #41's "refactor first (#7/#8)" caveat doesn't apply). Module-level caches are reset per-test via `vi.resetModules`.

## Verification (gates, run in Docker)

- ✅ **130/130 tests pass** (`pnpm vitest run` on the 4 files)
- ✅ **type-check clean** (`tsc --noEmit`) — caught + fixed one enum-as-type annotation (dynamic-import value vs static type)
- ✅ **lint clean** (eslint exit 0)

Known partial coverage (documented, intentional): `sendMessage`'s deep online send-retry internals (23505 conflict retry + exponential network-backoff) aren't exercised — the happy path, offline-queue, validation, and session-retry branches are. Can extend if desired.

Part of the #115 backlog sweep. 🤖 Generated with [Claude Code](https://claude.com/claude-code)