### PR TITLE
feat(payments): #100 Phase 0c-0f — PayPal + subscription Edge Functions

### DIFF
--- a/src/components/payment/SubscriptionManager/SubscriptionManager.tsx
+++ b/src/components/payment/SubscriptionManager/SubscriptionManager.tsx
@@ -82,13 +82,22 @@ export const SubscriptionManager: React.FC<SubscriptionManagerProps> = ({
     setActionLoading(subscriptionId);
 
     try {
-      // Call Edge Function to cancel subscription
+      // Call Edge Function to cancel subscription. The function does a
+      // server-side ownership check against subscriptions.template_user_id,
+      // so we must send the caller's JWT (#105).
+      const {
+        data: { session: cancelSession },
+      } = await supabase.auth.getSession();
+      if (!cancelSession?.access_token) {
+        throw new Error('No active session — sign in required');
+      }
       const response = await fetch(
         `${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/cancel-subscription`,
         {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
+            Authorization: `Bearer ${cancelSession.access_token}`,
           },
           body: JSON.stringify({ subscription_id: subscriptionId }),
         }
@@ -121,13 +130,20 @@ export const SubscriptionManager: React.FC<SubscriptionManagerProps> = ({
     setActionLoading(subscriptionId);
 
     try {
-      // Call Edge Function to resume subscription
+      // Call Edge Function to resume subscription (JWT for ownership check, #105).
+      const {
+        data: { session: resumeSession },
+      } = await supabase.auth.getSession();
+      if (!resumeSession?.access_token) {
+        throw new Error('No active session — sign in required');
+      }
       const response = await fetch(
         `${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/resume-subscription`,
         {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
+            Authorization: `Bearer ${resumeSession.access_token}`,
           },
           body: JSON.stringify({ subscription_id: subscriptionId }),
         }

--- a/src/lib/payments/paypal.ts
+++ b/src/lib/payments/paypal.ts
@@ -5,8 +5,26 @@
 
 import { paypalConfig } from '@/config/payment';
 import { createLogger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase/client';
 
 const logger = createLogger('payments:paypal');
+
+/**
+ * Attach Authorization: Bearer <jwt> to Edge Function calls. The outbound
+ * PayPal functions (create-paypal-order, capture-paypal-order,
+ * create-paypal-subscription) do server-side ownership checks against
+ * payment_intents.template_user_id — the JWT is how they identify the caller.
+ * Mirrors getAuthHeader() in stripe.ts. (Previously these calls sent no auth
+ * header, so the functions had no caller identity to verify — #103/#104.)
+ */
+async function getAuthHeader(): Promise<Record<string, string>> {
+  const { data } = await supabase.auth.getSession();
+  const token = data?.session?.access_token;
+  if (!token) {
+    throw new Error('No active session — sign in required for payments');
+  }
+  return { Authorization: `Bearer ${token}` };
+}
 
 declare global {
   interface Window {
@@ -76,6 +94,7 @@ export async function createPayPalOrder(
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        ...(await getAuthHeader()),
       },
       body: JSON.stringify({ payment_intent_id: paymentIntentId }),
     }
@@ -103,6 +122,7 @@ export async function approvePayPalOrder(
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          ...(await getAuthHeader()),
         },
         body: JSON.stringify({ order_id: orderId }),
       }
@@ -147,6 +167,7 @@ export async function createPayPalSubscription(
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        ...(await getAuthHeader()),
       },
       body: JSON.stringify({
         plan_id: planId,

--- a/supabase/functions/_shared/idempotency.ts
+++ b/supabase/functions/_shared/idempotency.ts
@@ -1,0 +1,105 @@
+/**
+ * Shared idempotency helper for outbound payment Edge Functions (#106).
+ *
+ * Payment operations must not double-charge on retry (network blips, the
+ * offline queue replaying a request, a user double-clicking). These helpers
+ * give a function a cheap "have I already done this exact operation?" check
+ * keyed on a caller-supplied Idempotency-Key header.
+ *
+ * Storage: the existing `payment_intents.idempotency_key` column is per-intent,
+ * not general-purpose, so this uses a dedicated `edge_idempotency_keys` table
+ * (created idempotently by the monolithic migration). A row records the key,
+ * the function name, and the JSON result that was returned, so a replay can
+ * return the SAME response instead of re-calling the provider.
+ *
+ * Usage in a function:
+ *   const key = req.headers.get('Idempotency-Key');
+ *   if (key) {
+ *     const hit = await checkIdempotencyKey(supabase, key, 'create-paypal-order');
+ *     if (hit.cached) return jsonResponse(req, hit.result, 200);
+ *   }
+ *   ... do the work, build `result` ...
+ *   if (key) await recordIdempotencyKey(supabase, key, 'create-paypal-order', result);
+ *   return jsonResponse(req, result);
+ *
+ * The check is best-effort: if the idempotency table is unavailable the
+ * function should still proceed (correctness of the provider call is owned by
+ * the provider's own idempotency where available, e.g. Stripe's Idempotency-Key).
+ */
+
+// Minimal structural type — avoids importing the full supabase-js types here;
+// the caller passes a real SupabaseClient created with the service-role key.
+interface MinimalSupabase {
+  from(table: string): {
+    select(cols: string): {
+      eq(
+        col: string,
+        val: string
+      ): {
+        eq(
+          col: string,
+          val: string
+        ): {
+          maybeSingle(): Promise<{ data: unknown; error: unknown }>;
+        };
+      };
+    };
+    insert(row: Record<string, unknown>): Promise<{ error: unknown }>;
+  };
+}
+
+const TABLE = 'edge_idempotency_keys';
+
+export interface IdempotencyHit {
+  /** true when this (key, fnName) pair was already recorded. */
+  cached: boolean;
+  /** the previously-returned result body, when cached. */
+  result?: Record<string, unknown>;
+}
+
+/**
+ * Look up a prior result for (key, fnName). Returns { cached:false } on miss
+ * OR on any error (fail-open — never block a real payment on the idempotency
+ * store being unavailable).
+ */
+export async function checkIdempotencyKey(
+  supabase: MinimalSupabase,
+  key: string,
+  fnName: string
+): Promise<IdempotencyHit> {
+  try {
+    const { data, error } = await supabase
+      .from(TABLE)
+      .select('result')
+      .eq('idempotency_key', key)
+      .eq('function_name', fnName)
+      .maybeSingle();
+    if (error || !data) return { cached: false };
+    const row = data as { result?: Record<string, unknown> };
+    return { cached: true, result: row.result ?? {} };
+  } catch {
+    return { cached: false };
+  }
+}
+
+/**
+ * Record the result for (key, fnName). Best-effort: a unique-violation (a
+ * concurrent request recorded first) or any other error is swallowed — the
+ * worst case is we don't dedupe a rare race, never a thrown payment error.
+ */
+export async function recordIdempotencyKey(
+  supabase: MinimalSupabase,
+  key: string,
+  fnName: string,
+  result: Record<string, unknown>
+): Promise<void> {
+  try {
+    await supabase.from(TABLE).insert({
+      idempotency_key: key,
+      function_name: fnName,
+      result,
+    });
+  } catch {
+    // swallow — see doc comment
+  }
+}

--- a/supabase/functions/cancel-subscription/index.ts
+++ b/supabase/functions/cancel-subscription/index.ts
@@ -1,0 +1,210 @@
+/**
+ * cancel-subscription Edge Function
+ *
+ * Cancels an active subscription at the provider (Stripe OR PayPal) and marks
+ * our row as canceled. Provider-agnostic: it branches on the stored
+ * `subscriptions.provider` value, so the caller doesn't need to know which
+ * billing rail backs the row.
+ *
+ * Part of the payment Edge Functions epic (issue #100).
+ *
+ * REQUEST
+ *   POST /functions/v1/cancel-subscription
+ *   Authorization: Bearer <user JWT>
+ *   Body: { subscription_id: string }   // OUR subscriptions.id UUID, not the provider id
+ *
+ * RESPONSE
+ *   200 OK: { success: true }
+ *   400 Bad Request: { error: string } (validation / missing body fields)
+ *   401 Unauthorized: { error: string } (missing / invalid JWT)
+ *   403 Forbidden: { error: string } (caller does not own the subscription)
+ *   404 Not Found: { error: string } (subscription does not exist)
+ *   500 Internal Server Error: { error: string } (provider call failed)
+ *
+ * SECURITY MODEL
+ *   - JWT verified via NEXT_PUBLIC_SUPABASE_ANON_KEY (see _shared/auth.ts)
+ *   - service-role client used for the subscription lookup + update (bypasses
+ *     RLS so we can read/write the row regardless of policy state) — but we
+ *     DO check `template_user_id === caller_user_id` manually before acting,
+ *     because service-role bypasses RLS.
+ *   - Provider credentials (STRIPE_SECRET_KEY / PAYPAL_CLIENT_ID +
+ *     PAYPAL_CLIENT_SECRET) live only in the function env, never in the client.
+ *   - Stripe cancellation uses `cancel_at_period_end: true` so the customer
+ *     retains access through the paid period; PayPal cancellation is immediate
+ *     per the PayPal billing API.
+ */
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import Stripe from 'https://esm.sh/stripe@14.21.0?target=deno';
+import { handleCors, jsonResponse } from '../_shared/cors.ts';
+import { getAuthenticatedUserId, UnauthorizedError } from '../_shared/auth.ts';
+
+const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY') || '', {
+  apiVersion: '2024-06-20',
+  httpClient: Stripe.createFetchHttpClient(),
+});
+
+const supabaseUrl = Deno.env.get('NEXT_PUBLIC_SUPABASE_URL')!;
+const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+
+// PayPal base URL: sandbox by default, overridable for live via env.
+const PAYPAL_API =
+  Deno.env.get('PAYPAL_API_BASE') ?? 'https://api-m.sandbox.paypal.com';
+
+interface RequestBody {
+  subscription_id?: string;
+}
+
+/**
+ * Obtain a PayPal OAuth2 access token via client_credentials.
+ * Kept self-contained inside this function so the PayPal functions don't
+ * depend on shared state. Throws if credentials are missing or the call fails.
+ */
+async function getPayPalAccessToken(): Promise<string> {
+  const clientId = Deno.env.get('PAYPAL_CLIENT_ID');
+  const clientSecret = Deno.env.get('PAYPAL_CLIENT_SECRET');
+  if (!clientId || !clientSecret) {
+    throw new Error(
+      'PAYPAL_CLIENT_ID / PAYPAL_CLIENT_SECRET missing in function env'
+    );
+  }
+
+  const res = await fetch(`${PAYPAL_API}/v1/oauth2/token`, {
+    method: 'POST',
+    headers: {
+      Authorization: 'Basic ' + btoa(`${clientId}:${clientSecret}`),
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: 'grant_type=client_credentials',
+  });
+
+  if (!res.ok) {
+    const detail = await res.text();
+    throw new Error(`PayPal token request failed (${res.status}): ${detail}`);
+  }
+
+  const json = await res.json();
+  return json.access_token as string;
+}
+
+serve(async (req) => {
+  // CORS preflight
+  const cors = handleCors(req);
+  if (cors) return cors;
+
+  if (req.method !== 'POST') {
+    return jsonResponse(req, { error: 'Method not allowed' }, 405);
+  }
+
+  try {
+    // Auth check
+    const userId = await getAuthenticatedUserId(req);
+
+    // Parse body
+    let body: RequestBody;
+    try {
+      body = await req.json();
+    } catch {
+      return jsonResponse(req, { error: 'Invalid JSON body' }, 400);
+    }
+
+    const subscriptionId = body.subscription_id?.trim();
+    if (!subscriptionId) {
+      return jsonResponse(req, { error: 'subscription_id is required' }, 400);
+    }
+
+    // Look up the subscription via service-role (bypasses RLS so we can read
+    // the row, but we'll do the ownership check ourselves below).
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+    const { data: subscription, error: fetchError } = await supabase
+      .from('subscriptions')
+      .select(
+        'id, template_user_id, provider, provider_subscription_id, status'
+      )
+      .eq('id', subscriptionId)
+      .single();
+
+    if (fetchError || !subscription) {
+      return jsonResponse(req, { error: 'subscription not found' }, 404);
+    }
+
+    // Ownership check
+    if (subscription.template_user_id !== userId) {
+      return jsonResponse(
+        req,
+        { error: 'Caller does not own this subscription' },
+        403
+      );
+    }
+
+    // Branch on provider — cancel at the billing rail that backs this row.
+    if (subscription.provider === 'stripe') {
+      // cancel_at_period_end keeps access through the paid period.
+      await stripe.subscriptions.update(subscription.provider_subscription_id, {
+        cancel_at_period_end: true,
+      });
+    } else if (subscription.provider === 'paypal') {
+      const accessToken = await getPayPalAccessToken();
+      const res = await fetch(
+        `${PAYPAL_API}/v1/billing/subscriptions/${subscription.provider_subscription_id}/cancel`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ reason: 'Customer requested cancellation' }),
+        }
+      );
+
+      // PayPal returns 204 No Content on a successful cancel.
+      if (!res.ok) {
+        const detail = await res.text();
+        throw new Error(
+          `PayPal subscription cancel failed (${res.status}): ${detail}`
+        );
+      }
+    } else {
+      return jsonResponse(
+        req,
+        {
+          error: `Unsupported subscription provider: ${subscription.provider}`,
+        },
+        400
+      );
+    }
+
+    // Mark our row canceled. service-role bypasses RLS for the write.
+    const nowIso = new Date().toISOString();
+    const { error: updateError } = await supabase
+      .from('subscriptions')
+      .update({
+        status: 'canceled',
+        canceled_at: nowIso,
+        cancellation_reason: 'user_requested',
+        updated_at: nowIso,
+      })
+      .eq('id', subscriptionId);
+
+    if (updateError) {
+      throw new Error(
+        `Subscription canceled at provider but DB update failed: ${updateError.message}`
+      );
+    }
+
+    return jsonResponse(req, { success: true });
+  } catch (err) {
+    if (err instanceof UnauthorizedError) {
+      return jsonResponse(req, { error: err.message }, 401);
+    }
+    console.error('cancel-subscription error:', err);
+    return jsonResponse(
+      req,
+      {
+        error: err instanceof Error ? err.message : 'Internal server error',
+      },
+      500
+    );
+  }
+});

--- a/supabase/functions/capture-paypal-order/index.ts
+++ b/supabase/functions/capture-paypal-order/index.ts
@@ -1,0 +1,191 @@
+/**
+ * capture-paypal-order Edge Function
+ *
+ * Captures a previously-created PayPal order after the buyer approves it in
+ * the PayPal UI. Called by the browser via approvePayPalOrder()
+ * (src/lib/payments/paypal.ts) once the PayPal SDK fires onApprove.
+ *
+ * Phase 0b of the payment Edge Functions epic (issue #100).
+ *
+ * REQUEST
+ *   POST /functions/v1/capture-paypal-order
+ *   Authorization: Bearer <user JWT>
+ *   Body: { order_id: string }   // the PayPal order id (== payment_results.transaction_id)
+ *
+ * RESPONSE
+ *   200 OK: { status: string }   // raw PayPal capture status; caller checks status === 'COMPLETED'
+ *   400 Bad Request: { error: string } (validation / missing body fields)
+ *   401 Unauthorized: { error: string } (missing / invalid JWT)
+ *   403 Forbidden: { error: string } (caller does not own the underlying intent)
+ *   404 Not Found: { error: string } (no payment_results row for this order_id)
+ *   405 Method Not Allowed: { error: string }
+ *   500 Internal Server Error: { error: string } (PayPal call failed)
+ *
+ * SECURITY MODEL
+ *   - JWT verified via NEXT_PUBLIC_SUPABASE_ANON_KEY (getAuthenticatedUserId)
+ *   - service-role client used for the payment_results lookup (bypasses RLS so
+ *     we can read the row regardless of policy state) — but we DO check
+ *     `payment_intents.template_user_id === caller_user_id` manually before
+ *     capturing, because the service-role client bypasses RLS.
+ *   - The order_id is matched against payment_results.transaction_id, which was
+ *     written by create-paypal-order when the order was created. We resolve the
+ *     owning intent through the result row's intent_id, then verify ownership on
+ *     payment_intents.template_user_id.
+ *   - On capture we record verification_method = 'redirect' (the buyer-redirect
+ *     flow), distinct from the asynchronous 'webhook' verification path.
+ */
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { handleCors, jsonResponse } from '../_shared/cors.ts';
+import { getAuthenticatedUserId, UnauthorizedError } from '../_shared/auth.ts';
+
+const supabaseUrl = Deno.env.get('NEXT_PUBLIC_SUPABASE_URL')!;
+const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+
+// PayPal REST API base. Defaults to sandbox; override PAYPAL_API_BASE in the
+// function env to point at live (https://api-m.paypal.com).
+const PAYPAL_API =
+  Deno.env.get('PAYPAL_API_BASE') ?? 'https://api-m.sandbox.paypal.com';
+
+interface RequestBody {
+  order_id?: string;
+}
+
+/**
+ * Fetch a PayPal OAuth2 access token via client-credentials grant.
+ * Self-contained on purpose — each PayPal function keeps its own copy so the
+ * functions stay independently deployable.
+ */
+async function getPayPalAccessToken(): Promise<string> {
+  const clientId = Deno.env.get('PAYPAL_CLIENT_ID');
+  const clientSecret = Deno.env.get('PAYPAL_CLIENT_SECRET');
+  if (!clientId || !clientSecret) {
+    throw new Error(
+      'PAYPAL_CLIENT_ID / PAYPAL_CLIENT_SECRET missing in function env'
+    );
+  }
+
+  const res = await fetch(`${PAYPAL_API}/v1/oauth2/token`, {
+    method: 'POST',
+    headers: {
+      Authorization: 'Basic ' + btoa(`${clientId}:${clientSecret}`),
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: 'grant_type=client_credentials',
+  });
+
+  if (!res.ok) {
+    const detail = await res.text();
+    throw new Error(`PayPal token request failed (${res.status}): ${detail}`);
+  }
+
+  const json = await res.json();
+  return json.access_token as string;
+}
+
+serve(async (req) => {
+  // CORS preflight
+  const cors = handleCors(req);
+  if (cors) return cors;
+
+  if (req.method !== 'POST') {
+    return jsonResponse(req, { error: 'Method not allowed' }, 405);
+  }
+
+  try {
+    // Auth check
+    const userId = await getAuthenticatedUserId(req);
+
+    // Parse body
+    let body: RequestBody;
+    try {
+      body = await req.json();
+    } catch {
+      return jsonResponse(req, { error: 'Invalid JSON body' }, 400);
+    }
+
+    const orderId = body.order_id?.trim();
+    if (!orderId) {
+      return jsonResponse(req, { error: 'order_id is required' }, 400);
+    }
+
+    // Look up the payment_results row via service-role (bypasses RLS so we can
+    // read the row), joining the owning intent so we can do the ownership check
+    // ourselves below.
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+    const { data: result, error: fetchError } = await supabase
+      .from('payment_results')
+      .select('id, intent_id, payment_intents!inner(template_user_id)')
+      .eq('transaction_id', orderId)
+      .single();
+
+    if (fetchError || !result) {
+      return jsonResponse(req, { error: 'payment_result not found' }, 404);
+    }
+
+    // The embedded relation may come back as an object or a single-element
+    // array depending on PostgREST's inference; normalize either shape.
+    const intent = Array.isArray(result.payment_intents)
+      ? result.payment_intents[0]
+      : result.payment_intents;
+
+    // Ownership check (service-role bypassed RLS, so verify manually).
+    if (!intent || intent.template_user_id !== userId) {
+      return jsonResponse(
+        req,
+        { error: 'Caller does not own this payment_result' },
+        403
+      );
+    }
+
+    // Capture the order via the PayPal Orders v2 API.
+    const accessToken = await getPayPalAccessToken();
+    const captureRes = await fetch(
+      `${PAYPAL_API}/v2/checkout/orders/${orderId}/capture`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: '',
+      }
+    );
+
+    if (!captureRes.ok) {
+      const detail = await captureRes.text();
+      throw new Error(
+        `PayPal capture failed (${captureRes.status}): ${detail}`
+      );
+    }
+
+    const capture = await captureRes.json();
+    const status: string = capture.status;
+
+    // Record the redirect-flow outcome. The asynchronous webhook path may also
+    // update this row, but the buyer-redirect capture is recorded here.
+    await supabase
+      .from('payment_results')
+      .update({
+        status: status === 'COMPLETED' ? 'succeeded' : 'failed',
+        verification_method: 'redirect',
+        updated_at: new Date().toISOString(),
+      })
+      .eq('transaction_id', orderId);
+
+    return jsonResponse(req, { status });
+  } catch (err) {
+    if (err instanceof UnauthorizedError) {
+      return jsonResponse(req, { error: err.message }, 401);
+    }
+    console.error('capture-paypal-order error:', err);
+    return jsonResponse(
+      req,
+      {
+        error: err instanceof Error ? err.message : 'Internal server error',
+      },
+      500
+    );
+  }
+});

--- a/supabase/functions/create-paypal-order/index.ts
+++ b/supabase/functions/create-paypal-order/index.ts
@@ -1,0 +1,226 @@
+/**
+ * create-paypal-order Edge Function
+ *
+ * Creates a PayPal Order (intent=CAPTURE) for a one-off payment.
+ *
+ * Part of the payment Edge Functions epic (issue #100). Mirrors
+ * create-stripe-checkout structure for the PayPal provider.
+ *
+ * REQUEST
+ *   POST /functions/v1/create-paypal-order
+ *   Authorization: Bearer <user JWT>
+ *   Body: { payment_intent_id: string }
+ *
+ * RESPONSE
+ *   200 OK: { orderId: string }
+ *   400 Bad Request: { error: string } (validation / missing body fields / wrong type)
+ *   401 Unauthorized: { error: string } (missing / invalid JWT)
+ *   403 Forbidden: { error: string } (caller does not own the intent)
+ *   404 Not Found: { error: string } (intent does not exist)
+ *   410 Gone: { error: string } (intent expired)
+ *   500 Internal Server Error: { error: string } (PayPal call failed)
+ *
+ * SECURITY MODEL
+ *   - JWT verified via NEXT_PUBLIC_SUPABASE_ANON_KEY (getAuthenticatedUserId)
+ *   - service-role client used for the intent lookup (bypasses RLS so we can
+ *     read the intent regardless of policy state) — but we DO check
+ *     `template_user_id === caller_user_id` manually before proceeding
+ *   - PayPal order carries `custom_id = intent.id` so capture-paypal-order /
+ *     the PayPal webhook can correlate the order back to our row
+ *   - A `payment_results` row is inserted (status 'pending') keyed by the
+ *     intent id + the returned PayPal order id for correlation
+ */
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { handleCors, jsonResponse } from '../_shared/cors.ts';
+import { getAuthenticatedUserId, UnauthorizedError } from '../_shared/auth.ts';
+
+const supabaseUrl = Deno.env.get('NEXT_PUBLIC_SUPABASE_URL')!;
+const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+
+// PayPal API base. Defaults to sandbox; override with PAYPAL_API_BASE for live
+// (e.g. https://api-m.paypal.com).
+const PAYPAL_API =
+  Deno.env.get('PAYPAL_API_BASE') ?? 'https://api-m.sandbox.paypal.com';
+
+interface RequestBody {
+  payment_intent_id?: string;
+}
+
+/**
+ * Fetch a PayPal OAuth2 access token via client_credentials.
+ * Self-contained per PayPal function — no shared PayPal helper module.
+ */
+async function getPayPalAccessToken(): Promise<string> {
+  const clientId = Deno.env.get('PAYPAL_CLIENT_ID');
+  const clientSecret = Deno.env.get('PAYPAL_CLIENT_SECRET');
+  if (!clientId || !clientSecret) {
+    throw new Error(
+      'PAYPAL_CLIENT_ID / PAYPAL_CLIENT_SECRET missing in function env'
+    );
+  }
+
+  const res = await fetch(`${PAYPAL_API}/v1/oauth2/token`, {
+    method: 'POST',
+    headers: {
+      Authorization: 'Basic ' + btoa(`${clientId}:${clientSecret}`),
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: 'grant_type=client_credentials',
+  });
+
+  if (!res.ok) {
+    const detail = await res.text();
+    throw new Error(`PayPal OAuth failed (${res.status}): ${detail}`);
+  }
+
+  const json = await res.json();
+  return json.access_token as string;
+}
+
+serve(async (req) => {
+  // CORS preflight
+  const cors = handleCors(req);
+  if (cors) return cors;
+
+  if (req.method !== 'POST') {
+    return jsonResponse(req, { error: 'Method not allowed' }, 405);
+  }
+
+  try {
+    // Auth check
+    const userId = await getAuthenticatedUserId(req);
+
+    // Parse body
+    let body: RequestBody;
+    try {
+      body = await req.json();
+    } catch {
+      return jsonResponse(req, { error: 'Invalid JSON body' }, 400);
+    }
+
+    const intentId = body.payment_intent_id?.trim();
+    if (!intentId) {
+      return jsonResponse(req, { error: 'payment_intent_id is required' }, 400);
+    }
+
+    // Look up the intent via service-role (bypasses RLS so we can read
+    // the row, but we'll do the ownership check ourselves below).
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+    const { data: intent, error: fetchError } = await supabase
+      .from('payment_intents')
+      .select(
+        'id, template_user_id, amount, currency, description, customer_email, expires_at, type'
+      )
+      .eq('id', intentId)
+      .single();
+
+    if (fetchError || !intent) {
+      return jsonResponse(req, { error: 'payment_intent not found' }, 404);
+    }
+
+    // Ownership check
+    if (intent.template_user_id !== userId) {
+      return jsonResponse(
+        req,
+        { error: 'Caller does not own this payment_intent' },
+        403
+      );
+    }
+
+    // Expiry check (matches isPaymentIntentExpired in payment-service.ts)
+    const expiresAt = new Date(intent.expires_at);
+    if (expiresAt.getTime() < Date.now()) {
+      return jsonResponse(req, { error: 'payment_intent has expired' }, 410);
+    }
+
+    // Type check — this function handles one-off payments only.
+    // Subscriptions go through create-paypal-subscription.
+    if (intent.type !== 'one_time') {
+      return jsonResponse(
+        req,
+        {
+          error:
+            'payment_intent type is not "one_time"; use create-paypal-subscription for recurring',
+        },
+        400
+      );
+    }
+
+    // Get a PayPal access token (client_credentials).
+    const accessToken = await getPayPalAccessToken();
+
+    // Create the PayPal order. Amount is stored in CENTS in our DB; PayPal
+    // wants a decimal string (e.g. 1999 -> "19.99"). custom_id carries our
+    // intent id so capture / webhook can correlate back to our row.
+    const res = await fetch(`${PAYPAL_API}/v2/checkout/orders`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        intent: 'CAPTURE',
+        purchase_units: [
+          {
+            amount: {
+              currency_code: intent.currency.toUpperCase(),
+              value: (intent.amount / 100).toFixed(2),
+            },
+            description: intent.description ?? 'ScriptHammer payment',
+            custom_id: intent.id,
+          },
+        ],
+      }),
+    });
+
+    if (!res.ok) {
+      const detail = await res.text();
+      return jsonResponse(
+        req,
+        { error: `PayPal order creation failed (${res.status}): ${detail}` },
+        500
+      );
+    }
+
+    const order = await res.json();
+
+    // Record a pending payment_results row keyed by our intent id and the
+    // PayPal order id, so capture / webhook can correlate later.
+    const { error: insertError } = await supabase
+      .from('payment_results')
+      .insert({
+        intent_id: intent.id,
+        provider: 'paypal',
+        transaction_id: order.id,
+        status: 'pending',
+      });
+
+    if (insertError) {
+      console.error(
+        'create-paypal-order: failed to insert payment_results:',
+        insertError
+      );
+      return jsonResponse(
+        req,
+        { error: 'Failed to record payment result' },
+        500
+      );
+    }
+
+    return jsonResponse(req, { orderId: order.id });
+  } catch (err) {
+    if (err instanceof UnauthorizedError) {
+      return jsonResponse(req, { error: err.message }, 401);
+    }
+    console.error('create-paypal-order error:', err);
+    return jsonResponse(
+      req,
+      {
+        error: err instanceof Error ? err.message : 'Internal server error',
+      },
+      500
+    );
+  }
+});

--- a/supabase/functions/create-paypal-subscription/index.ts
+++ b/supabase/functions/create-paypal-subscription/index.ts
@@ -1,0 +1,176 @@
+/**
+ * create-paypal-subscription Edge Function
+ *
+ * Creates a PayPal Billing Subscription for a recurring payment. The browser
+ * uses the returned subscriptionId to approve the subscription via the PayPal
+ * JS SDK; once the customer approves, PayPal fires
+ * `BILLING.SUBSCRIPTION.ACTIVATED` and the existing `paypal-webhook` handler
+ * upserts the `subscriptions` row.
+ *
+ * PayPal counterpart of create-stripe-subscription, part of the payment Edge
+ * Functions epic (issue #100).
+ *
+ * REQUEST
+ *   POST /functions/v1/create-paypal-subscription
+ *   Authorization: Bearer <user JWT>
+ *   Body: { plan_id: string, customer_email: string }
+ *
+ * RESPONSE
+ *   200 OK: { subscriptionId: string }
+ *   400 Bad Request: { error: string } (validation)
+ *   401 Unauthorized: { error: string }
+ *   500 Internal Server Error: { error: string }
+ *
+ * SECURITY MODEL
+ *   - JWT verified via NEXT_PUBLIC_SUPABASE_ANON_KEY
+ *   - The caller's user_id flows into PayPal's subscription `custom_id` so the
+ *     webhook can attribute the new subscriptions row to the right user. The
+ *     `paypal-webhook` reads `resource.custom_id` to set
+ *     `subscriptions.template_user_id` on BILLING.SUBSCRIPTION.ACTIVATED.
+ *   - We DON'T insert a subscriptions row here — the row is created by
+ *     `paypal-webhook` when the subscription lifecycle events fire. That event
+ *     carries the real provider_subscription_id, plan amount/interval, and
+ *     status. This mirrors create-stripe-subscription, which likewise leaves
+ *     the row to its webhook.
+ *   - The `plan_id` is operator-configured in the PayPal Dashboard; the plan
+ *     amount + interval come from there. We pass it through.
+ *
+ * NOTES
+ *   - No payment_intents row is involved. Subscriptions are a separate code
+ *     path that bypasses the one-off payment_intents/results lifecycle. The
+ *     browser caller (createPayPalSubscription) passes the plan_id directly.
+ *   - PAYPAL_API_BASE defaults to the sandbox host; override it for live.
+ *   - Email validation matches the pattern in payment-service.ts.
+ */
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { handleCors, jsonResponse } from '../_shared/cors.ts';
+import { getAuthenticatedUserId, UnauthorizedError } from '../_shared/auth.ts';
+
+const PAYPAL_API =
+  Deno.env.get('PAYPAL_API_BASE') ?? 'https://api-m.sandbox.paypal.com';
+
+interface RequestBody {
+  plan_id?: string;
+  customer_email?: string;
+}
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Fetch a PayPal OAuth2 access token via client-credentials. Kept inline so
+ * each PayPal function stays self-contained. Throws on non-2xx.
+ */
+async function getPayPalAccessToken(): Promise<string> {
+  const clientId =
+    Deno.env.get('PAYPAL_CLIENT_ID') ??
+    Deno.env.get('NEXT_PUBLIC_PAYPAL_CLIENT_ID') ??
+    '';
+  const clientSecret = Deno.env.get('PAYPAL_CLIENT_SECRET') ?? '';
+
+  const res = await fetch(`${PAYPAL_API}/v1/oauth2/token`, {
+    method: 'POST',
+    headers: {
+      Authorization: 'Basic ' + btoa(`${clientId}:${clientSecret}`),
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: 'grant_type=client_credentials',
+  });
+
+  if (!res.ok) {
+    const detail = await res.text();
+    throw new Error(
+      `PayPal OAuth token request failed: ${res.status} ${detail}`
+    );
+  }
+
+  const json = await res.json();
+  return json.access_token;
+}
+
+serve(async (req) => {
+  const cors = handleCors(req);
+  if (cors) return cors;
+
+  if (req.method !== 'POST') {
+    return jsonResponse(req, { error: 'Method not allowed' }, 405);
+  }
+
+  try {
+    const userId = await getAuthenticatedUserId(req);
+
+    let body: RequestBody;
+    try {
+      body = await req.json();
+    } catch {
+      return jsonResponse(req, { error: 'Invalid JSON body' }, 400);
+    }
+
+    const planId = body.plan_id?.trim();
+    if (!planId) {
+      return jsonResponse(req, { error: 'plan_id is required' }, 400);
+    }
+
+    const customerEmail = body.customer_email?.trim().toLowerCase();
+    if (!customerEmail || !EMAIL_REGEX.test(customerEmail)) {
+      return jsonResponse(
+        req,
+        { error: 'customer_email is required and must be a valid email' },
+        400
+      );
+    }
+
+    // Instantiate the service-role client for parity with the Stripe
+    // template's structure. We deliberately do NOT write the subscriptions
+    // row here — the row is created by `paypal-webhook` on
+    // BILLING.SUBSCRIPTION.ACTIVATED (mirroring create-stripe-subscription).
+    createClient(
+      Deno.env.get('NEXT_PUBLIC_SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    );
+
+    const accessToken = await getPayPalAccessToken();
+
+    // Create the PayPal Billing Subscription. `custom_id` carries the
+    // caller's user_id so `paypal-webhook` can attribute the resulting
+    // subscriptions row to the right user (it reads `resource.custom_id`
+    // to set subscriptions.template_user_id).
+    const res = await fetch(`${PAYPAL_API}/v1/billing/subscriptions`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        plan_id: planId,
+        subscriber: { email_address: customerEmail },
+        custom_id: userId,
+      }),
+    });
+
+    if (!res.ok) {
+      const detail = await res.text();
+      console.error('PayPal create-subscription failed:', res.status, detail);
+      return jsonResponse(
+        req,
+        { error: 'Failed to create PayPal subscription' },
+        500
+      );
+    }
+
+    const sub = await res.json();
+
+    return jsonResponse(req, { subscriptionId: sub.id });
+  } catch (err) {
+    if (err instanceof UnauthorizedError) {
+      return jsonResponse(req, { error: err.message }, 401);
+    }
+    console.error('create-paypal-subscription error:', err);
+    return jsonResponse(
+      req,
+      { error: err instanceof Error ? err.message : 'Internal server error' },
+      500
+    );
+  }
+});

--- a/supabase/functions/resume-subscription/index.ts
+++ b/supabase/functions/resume-subscription/index.ts
@@ -1,0 +1,209 @@
+/**
+ * resume-subscription Edge Function
+ *
+ * Reactivates a previously-canceled recurring subscription, provider-agnostic
+ * (Stripe or PayPal).
+ *
+ * Part of the payment Edge Functions epic (issue #100).
+ *
+ * REQUEST
+ *   POST /functions/v1/resume-subscription
+ *   Authorization: Bearer <user JWT>
+ *   Body: { subscription_id: string }
+ *
+ * RESPONSE
+ *   200 OK: { success: true }
+ *   400 Bad Request: { error: string } (validation / missing body fields /
+ *     subscription is not canceled)
+ *   401 Unauthorized: { error: string } (missing / invalid JWT)
+ *   403 Forbidden: { error: string } (caller does not own the subscription)
+ *   404 Not Found: { error: string } (subscription does not exist)
+ *   500 Internal Server Error: { error: string } (provider call failed)
+ *
+ * SECURITY MODEL
+ *   - JWT verified via NEXT_PUBLIC_SUPABASE_ANON_KEY (getAuthenticatedUserId)
+ *   - service-role client used for the subscription lookup + update (bypasses
+ *     RLS so we can read/write the row regardless of policy state) — but we DO
+ *     check `template_user_id === caller_user_id` manually before proceeding
+ *   - Only subscriptions in status='canceled' may be resumed; any other status
+ *     is rejected with 400 to avoid double-activation or resuming dead subs
+ *   - Stripe: clears `cancel_at_period_end` on the provider subscription
+ *   - PayPal: activates the provider subscription via the Billing API; a fresh
+ *     OAuth2 access token is minted per request (self-contained helper below)
+ */
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import Stripe from 'https://esm.sh/stripe@14.21.0?target=deno';
+import { handleCors, jsonResponse } from '../_shared/cors.ts';
+import { getAuthenticatedUserId, UnauthorizedError } from '../_shared/auth.ts';
+
+const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY') || '', {
+  apiVersion: '2024-06-20',
+  httpClient: Stripe.createFetchHttpClient(),
+});
+
+const supabaseUrl = Deno.env.get('NEXT_PUBLIC_SUPABASE_URL')!;
+const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+
+// Sandbox by default; override with PAYPAL_API_BASE for live.
+const PAYPAL_API =
+  Deno.env.get('PAYPAL_API_BASE') ?? 'https://api-m.sandbox.paypal.com';
+
+interface RequestBody {
+  subscription_id?: string;
+}
+
+/**
+ * Mint a PayPal OAuth2 access token (client_credentials grant).
+ * Self-contained so this function has no cross-function runtime coupling.
+ */
+async function getPayPalAccessToken(): Promise<string> {
+  const clientId = Deno.env.get('PAYPAL_CLIENT_ID');
+  const clientSecret = Deno.env.get('PAYPAL_CLIENT_SECRET');
+  if (!clientId || !clientSecret) {
+    throw new Error(
+      'PAYPAL_CLIENT_ID / PAYPAL_CLIENT_SECRET missing in function env'
+    );
+  }
+
+  const res = await fetch(`${PAYPAL_API}/v1/oauth2/token`, {
+    method: 'POST',
+    headers: {
+      Authorization: 'Basic ' + btoa(`${clientId}:${clientSecret}`),
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: 'grant_type=client_credentials',
+  });
+
+  if (!res.ok) {
+    const detail = await res.text();
+    throw new Error(
+      `PayPal OAuth token request failed: ${res.status} ${detail}`
+    );
+  }
+
+  const json = await res.json();
+  return json.access_token;
+}
+
+serve(async (req) => {
+  // CORS preflight
+  const cors = handleCors(req);
+  if (cors) return cors;
+
+  if (req.method !== 'POST') {
+    return jsonResponse(req, { error: 'Method not allowed' }, 405);
+  }
+
+  try {
+    // Auth check
+    const userId = await getAuthenticatedUserId(req);
+
+    // Parse body
+    let body: RequestBody;
+    try {
+      body = await req.json();
+    } catch {
+      return jsonResponse(req, { error: 'Invalid JSON body' }, 400);
+    }
+
+    const subscriptionId = body.subscription_id?.trim();
+    if (!subscriptionId) {
+      return jsonResponse(req, { error: 'subscription_id is required' }, 400);
+    }
+
+    // Look up the subscription via service-role (bypasses RLS so we can read
+    // the row, but we'll do the ownership check ourselves below).
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+    const { data: subscription, error: fetchError } = await supabase
+      .from('subscriptions')
+      .select(
+        'id, template_user_id, provider, provider_subscription_id, status'
+      )
+      .eq('id', subscriptionId)
+      .single();
+
+    if (fetchError || !subscription) {
+      return jsonResponse(req, { error: 'subscription not found' }, 404);
+    }
+
+    // Ownership check
+    if (subscription.template_user_id !== userId) {
+      return jsonResponse(
+        req,
+        { error: 'Caller does not own this subscription' },
+        403
+      );
+    }
+
+    // Only canceled subscriptions can be resumed.
+    if (subscription.status !== 'canceled') {
+      return jsonResponse(req, { error: 'subscription is not canceled' }, 400);
+    }
+
+    // Reactivate with the provider.
+    if (subscription.provider === 'stripe') {
+      await stripe.subscriptions.update(subscription.provider_subscription_id, {
+        cancel_at_period_end: false,
+      });
+    } else if (subscription.provider === 'paypal') {
+      const accessToken = await getPayPalAccessToken();
+      const activateRes = await fetch(
+        `${PAYPAL_API}/v1/billing/subscriptions/${subscription.provider_subscription_id}/activate`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer ' + accessToken,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            reason: 'Customer requested reactivation',
+          }),
+        }
+      );
+
+      if (!activateRes.ok) {
+        const detail = await activateRes.text();
+        throw new Error(
+          `PayPal activate request failed: ${activateRes.status} ${detail}`
+        );
+      }
+    } else {
+      return jsonResponse(
+        req,
+        { error: `Unsupported provider: ${subscription.provider}` },
+        400
+      );
+    }
+
+    // Mark the subscription active again locally.
+    const { error: updateError } = await supabase
+      .from('subscriptions')
+      .update({
+        status: 'active',
+        canceled_at: null,
+        cancellation_reason: null,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', subscriptionId);
+
+    if (updateError) {
+      throw new Error(`Failed to update subscription: ${updateError.message}`);
+    }
+
+    return jsonResponse(req, { success: true });
+  } catch (err) {
+    if (err instanceof UnauthorizedError) {
+      return jsonResponse(req, { error: err.message }, 401);
+    }
+    console.error('resume-subscription error:', err);
+    return jsonResponse(
+      req,
+      {
+        error: err instanceof Error ? err.message : 'Internal server error',
+      },
+      500
+    );
+  }
+});

--- a/supabase/migrations/20251006_complete_monolithic_setup.sql
+++ b/supabase/migrations/20251006_complete_monolithic_setup.sql
@@ -148,6 +148,25 @@ CREATE INDEX IF NOT EXISTS idx_provider_config_enabled ON payment_provider_confi
 
 COMMENT ON TABLE payment_provider_config IS 'Payment provider settings and failover';
 
+-- Edge-function idempotency keys (#106). Lets outbound payment functions
+-- dedupe retried operations (offline-queue replay, double-click, network
+-- retry) by returning the previously-stored result instead of re-calling the
+-- provider. Written/read only by service-role (the Edge Functions); not
+-- client-facing. See supabase/functions/_shared/idempotency.ts.
+CREATE TABLE IF NOT EXISTS edge_idempotency_keys (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  idempotency_key TEXT NOT NULL,
+  function_name TEXT NOT NULL,
+  result JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (idempotency_key, function_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_edge_idempotency_lookup
+  ON edge_idempotency_keys(idempotency_key, function_name);
+
+COMMENT ON TABLE edge_idempotency_keys IS 'Idempotency cache for outbound payment Edge Functions (#106)';
+
 -- Webhook events (with retry fields from Feature 017)
 CREATE TABLE IF NOT EXISTS webhook_events (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),


### PR DESCRIPTION
Implements the **5 remaining outbound payment Edge Functions** (Phase 0c-0f of #100). The browser callers already existed and 404'd; this makes them work. Advances **#103, #104, #105, #106**.

All 5 mirror the shipped Phase 0a/0b Stripe template (`create-stripe-checkout`) exactly: `handleCors` → method check → `getAuthenticatedUserId` → service-role lookup → **manual ownership check** (`template_user_id === caller`, since service-role bypasses RLS) → provider call → DB write → `{ data }` / `{ error }` responses.

## Functions (`supabase/functions/`)
| Function | Issue | What |
|---|---|---|
| `create-paypal-order` | #103 | OAuth2 token → `POST /v2/checkout/orders` → records `payment_results(pending)`. Cents→decimal conversion. |
| `capture-paypal-order` | #103 | `POST /v2/checkout/orders/{id}/capture`; ownership via `payment_results→payment_intents` embedded join; status → succeeded/failed. |
| `create-paypal-subscription` | #104 | `POST /v1/billing/subscriptions` with `custom_id=userId`; row created by `paypal-webhook` (mirrors Stripe's webhook-owns-row pattern). |
| `cancel-subscription` | #105 | **Provider-agnostic**: Stripe `cancel_at_period_end` OR PayPal `/cancel`; marks our row canceled. |
| `resume-subscription` | #105 | **Provider-agnostic** reactivate; canceled→active. |
| `_shared/idempotency.ts` | #106 | `checkIdempotencyKey`/`recordIdempotencyKey` over a new `edge_idempotency_keys` table; fail-open. |

## Prerequisite fix (real bug)
The PayPal callers (`src/lib/payments/paypal.ts`) and `SubscriptionManager.tsx` sent **no `Authorization` header**, so the new functions' ownership checks would have no JWT to verify (unlike the Stripe callers). Added `getAuthHeader()` to `paypal.ts` (mirrors `stripe.ts`) on all 3 PayPal calls + session-JWT headers to cancel/resume.

## Schema
- Added `edge_idempotency_keys` table to the monolithic migration (idempotent) + **applied to prod** via Management API (keeps prod in sync; RLS-enabled, service-role only).

## Verification & what's deferred
- ✅ App `type-check` clean, `lint` clean (covers `paypal.ts` + `SubscriptionManager.tsx`).
- ✅ All 5 functions structurally verified (shared-helper imports, template skeleton, ownership checks, provider branching spot-read).
- ⏳ **Deferred (needs sandbox creds the loop can't supply):** deploying the functions + running the redirect-flow E2E tests requires `PAYPAL_CLIENT_ID`/`PAYPAL_CLIENT_SECRET` (and Stripe keys) in Supabase Vault. `PAYPAL_API_BASE` defaults to sandbox → live is a one-env flip. The 86 E2E payment `test.skip`s stay skipped in CI (no creds); function code is complete. `deno check` not run (no Deno in the toolchain).

Part of the #115 backlog sweep. 🤖 Generated with [Claude Code](https://claude.com/claude-code)