### PR TITLE
fix(types): regenerate Supabase types + fix masked payment-retry schema drift

### DIFF
--- a/src/components/molecular/UserAuditTrail/UserAuditTrail.tsx
+++ b/src/components/molecular/UserAuditTrail/UserAuditTrail.tsx
@@ -94,12 +94,7 @@ export default function UserAuditTrail({
         setEntries([]);
         return;
       }
-      // Cast via `unknown`: the generated src/lib/supabase/types.ts is stale —
-      // its `auth_audit_logs.Row` omits the `success` / `error_message` columns
-      // that exist in the live table + the monolithic migration, so the query
-      // builder mis-infers a SelectQueryError. The runtime row has `success`.
-      // (Regenerating the Supabase types is tracked separately, out of #23 scope.)
-      setEntries((data ?? []) as unknown as UserAuditEntry[]);
+      setEntries((data ?? []) as UserAuditEntry[]);
     }
 
     void load();

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -10,7 +10,7 @@ export type Database = {
   // Allows to automatically instantiate createClient with right options
   // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
-    PostgrestVersion: '13.0.5';
+    PostgrestVersion: '14.5';
   };
   graphql_public: {
     Tables: {
@@ -39,6 +39,409 @@ export type Database = {
   };
   public: {
     Tables: {
+      audit_logs: {
+        Row: {
+          created_at: string;
+          details: Json | null;
+          event_type: string;
+          id: string;
+          ip_address: unknown;
+          user_agent: string | null;
+          user_id: string | null;
+        };
+        Insert: {
+          created_at?: string;
+          details?: Json | null;
+          event_type: string;
+          id?: string;
+          ip_address?: unknown;
+          user_agent?: string | null;
+          user_id?: string | null;
+        };
+        Update: {
+          created_at?: string;
+          details?: Json | null;
+          event_type?: string;
+          id?: string;
+          ip_address?: unknown;
+          user_agent?: string | null;
+          user_id?: string | null;
+        };
+        Relationships: [];
+      };
+      auth_audit_logs: {
+        Row: {
+          created_at: string;
+          error_message: string | null;
+          event_data: Json | null;
+          event_type: string;
+          id: string;
+          ip_address: unknown;
+          success: boolean;
+          user_agent: string | null;
+          user_id: string | null;
+        };
+        Insert: {
+          created_at?: string;
+          error_message?: string | null;
+          event_data?: Json | null;
+          event_type: string;
+          id?: string;
+          ip_address?: unknown;
+          success?: boolean;
+          user_agent?: string | null;
+          user_id?: string | null;
+        };
+        Update: {
+          created_at?: string;
+          error_message?: string | null;
+          event_data?: Json | null;
+          event_type?: string;
+          id?: string;
+          ip_address?: unknown;
+          success?: boolean;
+          user_agent?: string | null;
+          user_id?: string | null;
+        };
+        Relationships: [];
+      };
+      conversation_keys: {
+        Row: {
+          conversation_id: string;
+          created_at: string;
+          encrypted_shared_secret: string;
+          id: string;
+          key_version: number;
+          user_id: string;
+        };
+        Insert: {
+          conversation_id: string;
+          created_at?: string;
+          encrypted_shared_secret: string;
+          id?: string;
+          key_version?: number;
+          user_id: string;
+        };
+        Update: {
+          conversation_id?: string;
+          created_at?: string;
+          encrypted_shared_secret?: string;
+          id?: string;
+          key_version?: number;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'conversation_keys_conversation_id_fkey';
+            columns: ['conversation_id'];
+            isOneToOne: false;
+            referencedRelation: 'conversations';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      conversation_members: {
+        Row: {
+          archived: boolean;
+          conversation_id: string;
+          id: string;
+          joined_at: string;
+          key_status: string;
+          key_version_joined: number;
+          left_at: string | null;
+          muted: boolean;
+          role: string;
+          user_id: string;
+        };
+        Insert: {
+          archived?: boolean;
+          conversation_id: string;
+          id?: string;
+          joined_at?: string;
+          key_status?: string;
+          key_version_joined?: number;
+          left_at?: string | null;
+          muted?: boolean;
+          role?: string;
+          user_id: string;
+        };
+        Update: {
+          archived?: boolean;
+          conversation_id?: string;
+          id?: string;
+          joined_at?: string;
+          key_status?: string;
+          key_version_joined?: number;
+          left_at?: string | null;
+          muted?: boolean;
+          role?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'conversation_members_conversation_id_fkey';
+            columns: ['conversation_id'];
+            isOneToOne: false;
+            referencedRelation: 'conversations';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'conversation_members_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'user_profiles';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      conversations: {
+        Row: {
+          archived_by_participant_1: boolean;
+          archived_by_participant_2: boolean;
+          created_at: string;
+          created_by: string | null;
+          current_key_version: number;
+          group_name: string | null;
+          id: string;
+          is_group: boolean;
+          last_message_at: string | null;
+          participant_1_id: string | null;
+          participant_2_id: string | null;
+        };
+        Insert: {
+          archived_by_participant_1?: boolean;
+          archived_by_participant_2?: boolean;
+          created_at?: string;
+          created_by?: string | null;
+          current_key_version?: number;
+          group_name?: string | null;
+          id?: string;
+          is_group?: boolean;
+          last_message_at?: string | null;
+          participant_1_id?: string | null;
+          participant_2_id?: string | null;
+        };
+        Update: {
+          archived_by_participant_1?: boolean;
+          archived_by_participant_2?: boolean;
+          created_at?: string;
+          created_by?: string | null;
+          current_key_version?: number;
+          group_name?: string | null;
+          id?: string;
+          is_group?: boolean;
+          last_message_at?: string | null;
+          participant_1_id?: string | null;
+          participant_2_id?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'conversations_created_by_fkey';
+            columns: ['created_by'];
+            isOneToOne: false;
+            referencedRelation: 'user_profiles';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'conversations_participant_1_id_fkey';
+            columns: ['participant_1_id'];
+            isOneToOne: false;
+            referencedRelation: 'user_profiles';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'conversations_participant_2_id_fkey';
+            columns: ['participant_2_id'];
+            isOneToOne: false;
+            referencedRelation: 'user_profiles';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      edge_idempotency_keys: {
+        Row: {
+          created_at: string;
+          function_name: string;
+          id: string;
+          idempotency_key: string;
+          result: Json;
+        };
+        Insert: {
+          created_at?: string;
+          function_name: string;
+          id?: string;
+          idempotency_key: string;
+          result: Json;
+        };
+        Update: {
+          created_at?: string;
+          function_name?: string;
+          id?: string;
+          idempotency_key?: string;
+          result?: Json;
+        };
+        Relationships: [];
+      };
+      group_keys: {
+        Row: {
+          conversation_id: string;
+          created_at: string;
+          created_by: string;
+          encrypted_key: string;
+          id: string;
+          key_version: number;
+          user_id: string;
+        };
+        Insert: {
+          conversation_id: string;
+          created_at?: string;
+          created_by: string;
+          encrypted_key: string;
+          id?: string;
+          key_version?: number;
+          user_id: string;
+        };
+        Update: {
+          conversation_id?: string;
+          created_at?: string;
+          created_by?: string;
+          encrypted_key?: string;
+          id?: string;
+          key_version?: number;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'group_keys_conversation_id_fkey';
+            columns: ['conversation_id'];
+            isOneToOne: false;
+            referencedRelation: 'conversations';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'group_keys_created_by_fkey';
+            columns: ['created_by'];
+            isOneToOne: false;
+            referencedRelation: 'user_profiles';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'group_keys_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'user_profiles';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      messages: {
+        Row: {
+          conversation_id: string;
+          created_at: string;
+          deleted: boolean;
+          delivered_at: string | null;
+          edited: boolean;
+          edited_at: string | null;
+          encrypted_content: string;
+          id: string;
+          initialization_vector: string;
+          is_system_message: boolean;
+          key_version: number;
+          read_at: string | null;
+          sender_id: string;
+          sequence_number: number;
+          system_message_type: string | null;
+        };
+        Insert: {
+          conversation_id: string;
+          created_at?: string;
+          deleted?: boolean;
+          delivered_at?: string | null;
+          edited?: boolean;
+          edited_at?: string | null;
+          encrypted_content: string;
+          id?: string;
+          initialization_vector: string;
+          is_system_message?: boolean;
+          key_version?: number;
+          read_at?: string | null;
+          sender_id: string;
+          sequence_number: number;
+          system_message_type?: string | null;
+        };
+        Update: {
+          conversation_id?: string;
+          created_at?: string;
+          deleted?: boolean;
+          delivered_at?: string | null;
+          edited?: boolean;
+          edited_at?: string | null;
+          encrypted_content?: string;
+          id?: string;
+          initialization_vector?: string;
+          is_system_message?: boolean;
+          key_version?: number;
+          read_at?: string | null;
+          sender_id?: string;
+          sequence_number?: number;
+          system_message_type?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'messages_conversation_id_fkey';
+            columns: ['conversation_id'];
+            isOneToOne: false;
+            referencedRelation: 'conversations';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'messages_sender_id_fkey';
+            columns: ['sender_id'];
+            isOneToOne: false;
+            referencedRelation: 'user_profiles';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      oauth_states: {
+        Row: {
+          created_at: string;
+          expires_at: string;
+          id: string;
+          ip_address: unknown;
+          provider: string;
+          return_url: string | null;
+          session_id: string | null;
+          state_token: string;
+          used: boolean;
+          user_agent: string | null;
+        };
+        Insert: {
+          created_at?: string;
+          expires_at?: string;
+          id?: string;
+          ip_address?: unknown;
+          provider: string;
+          return_url?: string | null;
+          session_id?: string | null;
+          state_token: string;
+          used?: boolean;
+          user_agent?: string | null;
+        };
+        Update: {
+          created_at?: string;
+          expires_at?: string;
+          id?: string;
+          ip_address?: unknown;
+          provider?: string;
+          return_url?: string | null;
+          session_id?: string | null;
+          state_token?: string;
+          used?: boolean;
+          user_agent?: string | null;
+        };
+        Relationships: [];
+      };
       payment_intents: {
         Row: {
           amount: number;
@@ -190,6 +593,72 @@ export type Database = {
           },
         ];
       };
+      profiles: {
+        Row: {
+          avatar_url: string | null;
+          bio: string | null;
+          created_at: string;
+          display_name: string | null;
+          id: string;
+          updated_at: string;
+        };
+        Insert: {
+          avatar_url?: string | null;
+          bio?: string | null;
+          created_at?: string;
+          display_name?: string | null;
+          id: string;
+          updated_at?: string;
+        };
+        Update: {
+          avatar_url?: string | null;
+          bio?: string | null;
+          created_at?: string;
+          display_name?: string | null;
+          id?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
+      rate_limit_attempts: {
+        Row: {
+          attempt_count: number;
+          attempt_type: string;
+          created_at: string;
+          id: string;
+          identifier: string;
+          ip_address: unknown;
+          locked_until: string | null;
+          updated_at: string;
+          user_agent: string | null;
+          window_start: string;
+        };
+        Insert: {
+          attempt_count?: number;
+          attempt_type: string;
+          created_at?: string;
+          id?: string;
+          identifier: string;
+          ip_address?: unknown;
+          locked_until?: string | null;
+          updated_at?: string;
+          user_agent?: string | null;
+          window_start?: string;
+        };
+        Update: {
+          attempt_count?: number;
+          attempt_type?: string;
+          created_at?: string;
+          id?: string;
+          identifier?: string;
+          ip_address?: unknown;
+          locked_until?: string | null;
+          updated_at?: string;
+          user_agent?: string | null;
+          window_start?: string;
+        };
+        Relationships: [];
+      };
       subscriptions: {
         Row: {
           canceled_at: string | null;
@@ -253,12 +722,173 @@ export type Database = {
         };
         Relationships: [];
       };
+      typing_indicators: {
+        Row: {
+          conversation_id: string;
+          id: string;
+          is_typing: boolean;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          conversation_id: string;
+          id?: string;
+          is_typing?: boolean;
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          conversation_id?: string;
+          id?: string;
+          is_typing?: boolean;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'typing_indicators_conversation_id_fkey';
+            columns: ['conversation_id'];
+            isOneToOne: false;
+            referencedRelation: 'conversations';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'typing_indicators_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'user_profiles';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      user_connections: {
+        Row: {
+          addressee_id: string;
+          created_at: string;
+          id: string;
+          requester_id: string;
+          status: string;
+          updated_at: string;
+        };
+        Insert: {
+          addressee_id: string;
+          created_at?: string;
+          id?: string;
+          requester_id: string;
+          status: string;
+          updated_at?: string;
+        };
+        Update: {
+          addressee_id?: string;
+          created_at?: string;
+          id?: string;
+          requester_id?: string;
+          status?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'user_connections_addressee_id_fkey';
+            columns: ['addressee_id'];
+            isOneToOne: false;
+            referencedRelation: 'user_profiles';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'user_connections_requester_id_fkey';
+            columns: ['requester_id'];
+            isOneToOne: false;
+            referencedRelation: 'user_profiles';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      user_encryption_keys: {
+        Row: {
+          created_at: string;
+          device_id: string | null;
+          encryption_salt: string | null;
+          expires_at: string | null;
+          id: string;
+          public_key: Json;
+          revoked: boolean;
+          user_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          device_id?: string | null;
+          encryption_salt?: string | null;
+          expires_at?: string | null;
+          id?: string;
+          public_key: Json;
+          revoked?: boolean;
+          user_id: string;
+        };
+        Update: {
+          created_at?: string;
+          device_id?: string | null;
+          encryption_salt?: string | null;
+          expires_at?: string | null;
+          id?: string;
+          public_key?: Json;
+          revoked?: boolean;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'user_encryption_keys_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'user_profiles';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      user_profiles: {
+        Row: {
+          avatar_url: string | null;
+          bio: string | null;
+          created_at: string;
+          display_name: string | null;
+          id: string;
+          is_admin: boolean;
+          updated_at: string;
+          username: string | null;
+          welcome_message_sent: boolean;
+        };
+        Insert: {
+          avatar_url?: string | null;
+          bio?: string | null;
+          created_at?: string;
+          display_name?: string | null;
+          id: string;
+          is_admin?: boolean;
+          updated_at?: string;
+          username?: string | null;
+          welcome_message_sent?: boolean;
+        };
+        Update: {
+          avatar_url?: string | null;
+          bio?: string | null;
+          created_at?: string;
+          display_name?: string | null;
+          id?: string;
+          is_admin?: boolean;
+          updated_at?: string;
+          username?: string | null;
+          welcome_message_sent?: boolean;
+        };
+        Relationships: [];
+      };
       webhook_events: {
         Row: {
           created_at: string;
           event_data: Json;
           event_type: string;
           id: string;
+          last_retry_at: string | null;
+          next_retry_at: string | null;
+          permanently_failed: boolean;
           processed: boolean;
           processed_at: string | null;
           processing_attempts: number;
@@ -267,6 +897,7 @@ export type Database = {
           provider_event_id: string;
           related_payment_id: string | null;
           related_subscription_id: string | null;
+          retry_count: number;
           signature: string;
           signature_verified: boolean;
         };
@@ -275,6 +906,9 @@ export type Database = {
           event_data: Json;
           event_type: string;
           id?: string;
+          last_retry_at?: string | null;
+          next_retry_at?: string | null;
+          permanently_failed?: boolean;
           processed?: boolean;
           processed_at?: string | null;
           processing_attempts?: number;
@@ -283,6 +917,7 @@ export type Database = {
           provider_event_id: string;
           related_payment_id?: string | null;
           related_subscription_id?: string | null;
+          retry_count?: number;
           signature: string;
           signature_verified?: boolean;
         };
@@ -291,6 +926,9 @@ export type Database = {
           event_data?: Json;
           event_type?: string;
           id?: string;
+          last_retry_at?: string | null;
+          next_retry_at?: string | null;
+          permanently_failed?: boolean;
           processed?: boolean;
           processed_at?: string | null;
           processing_attempts?: number;
@@ -299,6 +937,7 @@ export type Database = {
           provider_event_id?: string;
           related_payment_id?: string | null;
           related_subscription_id?: string | null;
+          retry_count?: number;
           signature?: string;
           signature_verified?: boolean;
         };
@@ -319,466 +958,68 @@ export type Database = {
           },
         ];
       };
-      user_profiles: {
-        Row: {
-          avatar_url: string | null;
-          bio: string | null;
-          created_at: string;
-          display_name: string | null;
-          id: string;
-          updated_at: string;
-          username: string | null;
-          welcome_message_sent: boolean;
-        };
-        Insert: {
-          avatar_url?: string | null;
-          bio?: string | null;
-          created_at?: string;
-          display_name?: string | null;
-          id: string;
-          updated_at?: string;
-          username?: string | null;
-          welcome_message_sent?: boolean;
-        };
-        Update: {
-          avatar_url?: string | null;
-          bio?: string | null;
-          created_at?: string;
-          display_name?: string | null;
-          id?: string;
-          updated_at?: string;
-          username?: string | null;
-          welcome_message_sent?: boolean;
-        };
-        Relationships: [
-          {
-            foreignKeyName: 'user_profiles_id_fkey';
-            columns: ['id'];
-            isOneToOne: true;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
-          },
-        ];
-      };
-      oauth_states: {
-        Row: {
-          id: string;
-          state_token: string;
-          provider: string;
-          session_id: string | null;
-          return_url: string | null;
-          ip_address: string | null;
-          user_agent: string | null;
-          used: boolean;
-          created_at: string;
-          expires_at: string;
-        };
-        Insert: {
-          id?: string;
-          state_token: string;
-          provider: string;
-          session_id?: string | null;
-          return_url?: string | null;
-          ip_address?: string | null;
-          user_agent?: string | null;
-          used?: boolean;
-          created_at?: string;
-          expires_at?: string;
-        };
-        Update: {
-          id?: string;
-          state_token?: string;
-          provider?: string;
-          session_id?: string | null;
-          return_url?: string | null;
-          ip_address?: string | null;
-          user_agent?: string | null;
-          used?: boolean;
-          created_at?: string;
-          expires_at?: string;
-        };
-        Relationships: [];
-      };
-      rate_limit_attempts: {
-        Row: {
-          id: string;
-          identifier: string;
-          attempt_type: string;
-          ip_address: string | null;
-          user_agent: string | null;
-          window_start: string;
-          attempt_count: number;
-          locked_until: string | null;
-          created_at: string;
-          updated_at: string;
-        };
-        Insert: {
-          id?: string;
-          identifier: string;
-          attempt_type: string;
-          ip_address?: string | null;
-          user_agent?: string | null;
-          window_start?: string;
-          attempt_count?: number;
-          locked_until?: string | null;
-          created_at?: string;
-          updated_at?: string;
-        };
-        Update: {
-          id?: string;
-          identifier?: string;
-          attempt_type?: string;
-          ip_address?: string | null;
-          user_agent?: string | null;
-          window_start?: string;
-          attempt_count?: number;
-          locked_until?: string | null;
-          created_at?: string;
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
-      auth_audit_logs: {
-        Row: {
-          created_at: string;
-          event_data: Json | null;
-          event_type: string;
-          id: string;
-          ip_address: string | null;
-          user_agent: string | null;
-          user_id: string | null;
-        };
-        Insert: {
-          created_at?: string;
-          event_data?: Json | null;
-          event_type: string;
-          id?: string;
-          ip_address?: string | null;
-          user_agent?: string | null;
-          user_id?: string | null;
-        };
-        Update: {
-          created_at?: string;
-          event_data?: Json | null;
-          event_type?: string;
-          id?: string;
-          ip_address?: string | null;
-          user_agent?: string | null;
-          user_id?: string | null;
-        };
-        Relationships: [
-          {
-            foreignKeyName: 'auth_audit_logs_user_id_fkey';
-            columns: ['user_id'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
-          },
-        ];
-      };
-      // ========================================================================
-      // Messaging Tables (added for type safety)
-      // ========================================================================
-      user_connections: {
-        Row: {
-          id: string;
-          requester_id: string;
-          addressee_id: string;
-          status: 'pending' | 'accepted' | 'blocked' | 'declined';
-          created_at: string;
-          updated_at: string;
-        };
-        Insert: {
-          id?: string;
-          requester_id: string;
-          addressee_id: string;
-          status: 'pending' | 'accepted' | 'blocked' | 'declined';
-          created_at?: string;
-          updated_at?: string;
-        };
-        Update: {
-          id?: string;
-          requester_id?: string;
-          addressee_id?: string;
-          status?: 'pending' | 'accepted' | 'blocked' | 'declined';
-          created_at?: string;
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
-      conversations: {
-        Row: {
-          id: string;
-          participant_1_id: string | null;
-          participant_2_id: string | null;
-          last_message_at: string | null;
-          archived_by_participant_1: boolean;
-          archived_by_participant_2: boolean;
-          created_at: string;
-          is_group: boolean;
-          group_name: string | null;
-          created_by: string | null;
-          current_key_version: number;
-        };
-        Insert: {
-          id?: string;
-          participant_1_id?: string | null;
-          participant_2_id?: string | null;
-          last_message_at?: string | null;
-          archived_by_participant_1?: boolean;
-          archived_by_participant_2?: boolean;
-          created_at?: string;
-          is_group?: boolean;
-          group_name?: string | null;
-          created_by?: string | null;
-          current_key_version?: number;
-        };
-        Update: {
-          id?: string;
-          participant_1_id?: string | null;
-          participant_2_id?: string | null;
-          last_message_at?: string | null;
-          archived_by_participant_1?: boolean;
-          archived_by_participant_2?: boolean;
-          created_at?: string;
-          is_group?: boolean;
-          group_name?: string | null;
-          created_by?: string | null;
-          current_key_version?: number;
-        };
-        Relationships: [];
-      };
-      conversation_members: {
-        Row: {
-          id: string;
-          conversation_id: string;
-          user_id: string;
-          role: 'owner' | 'member';
-          joined_at: string;
-          left_at: string | null;
-          key_version_joined: number;
-          key_status: 'active' | 'pending';
-          archived: boolean;
-          muted: boolean;
-        };
-        Insert: {
-          id?: string;
-          conversation_id: string;
-          user_id: string;
-          role?: 'owner' | 'member';
-          joined_at?: string;
-          left_at?: string | null;
-          key_version_joined?: number;
-          key_status?: 'active' | 'pending';
-          archived?: boolean;
-          muted?: boolean;
-        };
-        Update: {
-          id?: string;
-          conversation_id?: string;
-          user_id?: string;
-          role?: 'owner' | 'member';
-          joined_at?: string;
-          left_at?: string | null;
-          key_version_joined?: number;
-          key_status?: 'active' | 'pending';
-          archived?: boolean;
-          muted?: boolean;
-        };
-        Relationships: [];
-      };
-      group_keys: {
-        Row: {
-          id: string;
-          conversation_id: string;
-          user_id: string;
-          key_version: number;
-          encrypted_key: string;
-          created_at: string;
-          created_by: string;
-        };
-        Insert: {
-          id?: string;
-          conversation_id: string;
-          user_id: string;
-          key_version?: number;
-          encrypted_key: string;
-          created_at?: string;
-          created_by: string;
-        };
-        Update: {
-          id?: string;
-          conversation_id?: string;
-          user_id?: string;
-          key_version?: number;
-          encrypted_key?: string;
-          created_at?: string;
-          created_by?: string;
-        };
-        Relationships: [];
-      };
-      messages: {
-        Row: {
-          id: string;
-          conversation_id: string;
-          sender_id: string;
-          encrypted_content: string;
-          initialization_vector: string;
-          sequence_number: number;
-          deleted: boolean;
-          edited: boolean;
-          edited_at: string | null;
-          delivered_at: string | null;
-          read_at: string | null;
-          created_at: string;
-          key_version: number;
-          is_system_message: boolean;
-          system_message_type: string | null;
-        };
-        Insert: {
-          id?: string;
-          conversation_id: string;
-          sender_id: string;
-          encrypted_content: string;
-          initialization_vector: string;
-          sequence_number?: number;
-          deleted?: boolean;
-          edited?: boolean;
-          edited_at?: string | null;
-          delivered_at?: string | null;
-          read_at?: string | null;
-          created_at?: string;
-          key_version?: number;
-          is_system_message?: boolean;
-          system_message_type?: string | null;
-        };
-        Update: {
-          id?: string;
-          conversation_id?: string;
-          sender_id?: string;
-          encrypted_content?: string;
-          initialization_vector?: string;
-          sequence_number?: number;
-          deleted?: boolean;
-          edited?: boolean;
-          edited_at?: string | null;
-          delivered_at?: string | null;
-          read_at?: string | null;
-          created_at?: string;
-          key_version?: number;
-          is_system_message?: boolean;
-          system_message_type?: string | null;
-        };
-        Relationships: [];
-      };
-      user_encryption_keys: {
-        Row: {
-          id: string;
-          user_id: string;
-          public_key: Json;
-          encryption_salt: string | null;
-          device_id: string | null;
-          expires_at: string | null;
-          revoked: boolean;
-          created_at: string;
-        };
-        Insert: {
-          id?: string;
-          user_id: string;
-          public_key: Json;
-          encryption_salt?: string | null;
-          device_id?: string | null;
-          expires_at?: string | null;
-          revoked?: boolean;
-          created_at?: string;
-        };
-        Update: {
-          id?: string;
-          user_id?: string;
-          public_key?: Json;
-          encryption_salt?: string | null;
-          device_id?: string | null;
-          expires_at?: string | null;
-          revoked?: boolean;
-          created_at?: string;
-        };
-        Relationships: [];
-      };
-      conversation_keys: {
-        Row: {
-          id: string;
-          conversation_id: string;
-          user_id: string;
-          encrypted_shared_secret: string;
-          key_version: number;
-          created_at: string;
-        };
-        Insert: {
-          id?: string;
-          conversation_id: string;
-          user_id: string;
-          encrypted_shared_secret: string;
-          key_version?: number;
-          created_at?: string;
-        };
-        Update: {
-          id?: string;
-          conversation_id?: string;
-          user_id?: string;
-          encrypted_shared_secret?: string;
-          key_version?: number;
-          created_at?: string;
-        };
-        Relationships: [];
-      };
-      typing_indicators: {
-        Row: {
-          id: string;
-          conversation_id: string;
-          user_id: string;
-          is_typing: boolean;
-          updated_at: string;
-        };
-        Insert: {
-          id?: string;
-          conversation_id: string;
-          user_id: string;
-          is_typing?: boolean;
-          updated_at?: string;
-        };
-        Update: {
-          id?: string;
-          conversation_id?: string;
-          user_id?: string;
-          is_typing?: boolean;
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
     };
     Views: {
       [_ in never]: never;
     };
     Functions: {
-      delete_user: {
-        Args: Record<PropertyKey, never>;
-        Returns: void;
-      };
-      check_rate_limit: {
+      admin_audit_trends: {
         Args: {
-          p_identifier: string;
-          p_attempt_type: string;
-          p_ip_address: string | null;
+          p_burst_gap?: string;
+          p_burst_min_attempts?: number;
+          p_end?: string;
+          p_start?: string;
         };
         Returns: Json;
       };
+      admin_auth_stats: { Args: never; Returns: Json };
+      admin_conversation_list: {
+        Args: { p_limit?: number; p_offset?: number };
+        Returns: Json;
+      };
+      admin_list_users: {
+        Args: { p_limit?: number; p_offset?: number; p_search?: string };
+        Returns: Json;
+      };
+      admin_messaging_stats: { Args: never; Returns: Json };
+      admin_messaging_trends: {
+        Args: { p_end?: string; p_start?: string; p_top_limit?: number };
+        Returns: Json;
+      };
+      admin_overview: {
+        Args: { p_end?: string; p_start?: string };
+        Returns: Json;
+      };
+      admin_payment_stats: { Args: never; Returns: Json };
+      admin_payment_trends: {
+        Args: { p_end?: string; p_start?: string };
+        Returns: Json;
+      };
+      admin_user_stats: { Args: never; Returns: Json };
+      check_rate_limit: {
+        Args: {
+          p_attempt_type: string;
+          p_identifier: string;
+          p_ip_address?: unknown;
+        };
+        Returns: Json;
+      };
+      cleanup_old_audit_logs: { Args: never; Returns: undefined };
+      is_conversation_member: {
+        Args: { check_user_id?: string; conv_id: string };
+        Returns: boolean;
+      };
+      is_conversation_owner: {
+        Args: { check_user_id?: string; conv_id: string };
+        Returns: boolean;
+      };
       record_failed_attempt: {
         Args: {
-          p_identifier: string;
           p_attempt_type: string;
-          p_ip_address: string | null;
+          p_identifier: string;
+          p_ip_address?: unknown;
         };
-        Returns: void;
+        Returns: undefined;
       };
     };
     Enums: {

--- a/src/services/messaging/group-service.ts
+++ b/src/services/messaging/group-service.ts
@@ -363,6 +363,10 @@ export class GroupService {
         // System messages aren't E2E-encrypted; store a tiny JSON marker.
         encrypted_content: JSON.stringify({ type, ...extra }),
         initialization_vector: 'system',
+        // Placeholder — the assign_sequence_number() trigger overwrites this on
+        // insert (matches the offline path in message-service.ts:335/516). The
+        // column is NOT NULL so a value must be supplied client-side.
+        sequence_number: 0,
       });
     } catch (error) {
       logger.warn('Failed to record group system message', {


### PR DESCRIPTION
Regenerates `src/lib/supabase/types.ts` from the live schema (Supabase Management API — no local CLI install). The stale types were **masking real bugs**:

## What the regen surfaced + fixed

1. **`auth_audit_logs.success`/`error_message`** — were missing from the old types. Removed the boundary-cast workaround added in #131 (`UserAuditTrail.tsx`).
2. **Broken payment-retry feature (the big one).** The fresh types revealed that `payment_intents.retry_count` + `parent_intent_id` **don't exist in the live DB** — yet `payment-service.ts` (FR-009 retry limit) and `usePaymentRetryStatus.ts` read/write them. `retryPayment()` would have **failed at runtime**; only the mocked unit tests passed. The columns **are** in the monolithic migration (lines 69–76, #43/B1) — they were just **never applied to prod** (same drift class as #49). Applied the idempotent `ADD COLUMN IF NOT EXISTS` to prod via the Management API + verified. The feature now actually works.
3. **`messages.sequence_number`** — the stricter fresh types caught that my #26 `recordSystemMessage` insert omitted this required column; added the `:0` placeholder (the `assign_sequence_number()` trigger overwrites it, matching `message-service.ts`).

Also picks up `edge_idempotency_keys` (the #130 table) in the types.

## Verification
- ✅ type-check clean (was failing on `retry_count` until the prod columns were added)
- ✅ lint clean
- ✅ 41 affected tests pass (UserAuditTrail with cast removed, payment retry, group membership)

> Prod impact: 2 idempotent columns added to `payment_intents` (already in the migration file; this just reconciled prod). No data migration; defaults to 0/null.

Part of the #115 Tier-2 sweep (quick-win). 🤖 Generated with [Claude Code](https://claude.com/claude-code)