### PR TITLE
feat(email): #34 admin email-provider health dashboard

### DIFF
--- a/src/app/admin/AdminGate.tsx
+++ b/src/app/admin/AdminGate.tsx
@@ -82,6 +82,9 @@ export function AdminGate({ children }: { children: React.ReactNode }) {
         <Link href="/admin/messaging" className="tab">
           Messaging
         </Link>
+        <Link href="/admin/email" className="tab">
+          Email
+        </Link>
       </nav>
       {children}
     </div>

--- a/src/app/admin/email/page.tsx
+++ b/src/app/admin/email/page.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { EmailProviderHealth } from '@/components/organisms/EmailProviderHealth';
+import type { EmailRateLimitStatus } from '@/components/organisms/EmailProviderHealth';
+import { emailService } from '@/utils/email/email-service';
+import type { ProviderStatus } from '@/utils/email/types';
+
+/**
+ * /admin/email — provider health dashboard for the dual-provider email
+ * abstraction (#34). Layered inside src/app/admin/layout.tsx (ProtectedRoute →
+ * AdminGate). Reads emailService.getStatus() / getRateLimitStatus() and renders
+ * the EmailProviderHealth organism. Mirrors src/app/admin/payments/page.tsx.
+ */
+export default function AdminEmailPage() {
+  const [providers, setProviders] = useState<ProviderStatus[]>([]);
+  const [rateLimitStatus, setRateLimitStatus] =
+    useState<EmailRateLimitStatus | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const status = await emailService.getStatus();
+        const rateLimit = emailService.getRateLimitStatus();
+        if (cancelled) return;
+        setProviders(status);
+        setRateLimitStatus(rateLimit);
+      } catch (err) {
+        if (cancelled) return;
+        setError(
+          err instanceof Error ? err.message : 'Failed to load email status'
+        );
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-3xl font-bold">Email Provider Health</h1>
+      </div>
+
+      {error && (
+        <div className="alert alert-error mb-6" role="alert">
+          <span>{error}</span>
+        </div>
+      )}
+
+      <EmailProviderHealth
+        providers={providers}
+        rateLimitStatus={rateLimitStatus}
+        isLoading={isLoading}
+        testId="admin-email-health"
+      />
+    </div>
+  );
+}

--- a/src/components/organisms/EmailProviderHealth/EmailProviderHealth.accessibility.test.tsx
+++ b/src/components/organisms/EmailProviderHealth/EmailProviderHealth.accessibility.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import EmailProviderHealth from './EmailProviderHealth';
+import type { ProviderStatus } from '@/utils/email/types';
+
+expect.extend(toHaveNoViolations);
+
+const providers: ProviderStatus[] = [
+  {
+    name: 'Web3Forms',
+    priority: 1,
+    available: true,
+    failures: 0,
+    healthy: true,
+  },
+  {
+    name: 'EmailJS',
+    priority: 2,
+    available: false,
+    failures: 3,
+    healthy: false,
+    lastError: 'Network timeout',
+  },
+];
+
+const rateLimitStatus = {
+  remaining: 2,
+  resetTime: Date.parse('2026-06-06T12:00:00Z'),
+  isLimited: false,
+};
+
+describe('EmailProviderHealth Accessibility', () => {
+  it('should have no accessibility violations (with data)', async () => {
+    const { container } = render(
+      <EmailProviderHealth
+        providers={providers}
+        rateLimitStatus={rateLimitStatus}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('should have no accessibility violations (empty + loading states)', async () => {
+    const empty = render(
+      <EmailProviderHealth providers={[]} rateLimitStatus={rateLimitStatus} />
+    );
+    expect(await axe(empty.container)).toHaveNoViolations();
+
+    const loading = render(
+      <EmailProviderHealth providers={[]} rateLimitStatus={null} isLoading />
+    );
+    expect(await axe(loading.container)).toHaveNoViolations();
+  });
+
+  it('should have proper semantic HTML', () => {
+    const { container } = render(
+      <EmailProviderHealth
+        providers={providers}
+        rateLimitStatus={rateLimitStatus}
+      />
+    );
+    expect(container.firstChild).toBeInTheDocument();
+    const images = container.querySelectorAll('img');
+    images.forEach((img) => {
+      expect(img).toHaveAttribute('alt');
+    });
+  });
+});

--- a/src/components/organisms/EmailProviderHealth/EmailProviderHealth.stories.tsx
+++ b/src/components/organisms/EmailProviderHealth/EmailProviderHealth.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import EmailProviderHealth from './EmailProviderHealth';
+import type { ProviderStatus } from '@/utils/email/types';
+
+const healthyProviders: ProviderStatus[] = [
+  {
+    name: 'Web3Forms',
+    priority: 1,
+    available: true,
+    failures: 0,
+    healthy: true,
+  },
+  { name: 'EmailJS', priority: 2, available: true, failures: 0, healthy: true },
+];
+
+const degradedProviders: ProviderStatus[] = [
+  {
+    name: 'Web3Forms',
+    priority: 1,
+    available: true,
+    failures: 1,
+    healthy: true,
+  },
+  {
+    name: 'EmailJS',
+    priority: 2,
+    available: false,
+    failures: 5,
+    healthy: false,
+    lastError: 'HTTP 429: rate limit exceeded',
+  },
+];
+
+const okRateLimit = {
+  remaining: 4,
+  resetTime: Date.parse('2026-06-06T12:00:00Z'),
+  isLimited: false,
+};
+
+const meta: Meta<typeof EmailProviderHealth> = {
+  title: 'Components/Organisms/EmailProviderHealth',
+  component: EmailProviderHealth,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Admin-facing health dashboard for the dual-provider email abstraction (#34).',
+      },
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Healthy: Story = {
+  args: { providers: healthyProviders, rateLimitStatus: okRateLimit },
+};
+
+export const Degraded: Story = {
+  args: {
+    providers: degradedProviders,
+    rateLimitStatus: {
+      remaining: 0,
+      resetTime: okRateLimit.resetTime,
+      isLimited: true,
+    },
+  },
+};
+
+export const Loading: Story = {
+  args: { providers: [], rateLimitStatus: null, isLoading: true },
+};
+
+export const NoProviders: Story = {
+  args: { providers: [], rateLimitStatus: okRateLimit },
+};

--- a/src/components/organisms/EmailProviderHealth/EmailProviderHealth.test.tsx
+++ b/src/components/organisms/EmailProviderHealth/EmailProviderHealth.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import EmailProviderHealth from './EmailProviderHealth';
+import type { ProviderStatus } from '@/utils/email/types';
+
+const providers: ProviderStatus[] = [
+  {
+    name: 'Web3Forms',
+    priority: 1,
+    available: true,
+    failures: 0,
+    healthy: true,
+  },
+  {
+    name: 'EmailJS',
+    priority: 2,
+    available: false,
+    failures: 4,
+    healthy: false,
+    lastError: 'Network timeout',
+  },
+];
+
+const rateLimitStatus = {
+  remaining: 3,
+  resetTime: new Date('2026-06-06T12:00:00Z').getTime(),
+  isLimited: false,
+};
+
+describe('EmailProviderHealth', () => {
+  it('renders a loading skeleton when isLoading', () => {
+    render(
+      <EmailProviderHealth providers={[]} rateLimitStatus={null} isLoading />
+    );
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(
+      screen.getByText(/loading email provider health/i)
+    ).toBeInTheDocument();
+  });
+
+  it('renders one card per provider with priority and failures', () => {
+    render(
+      <EmailProviderHealth
+        providers={providers}
+        rateLimitStatus={rateLimitStatus}
+      />
+    );
+    expect(screen.getByTestId('email-provider-Web3Forms')).toBeInTheDocument();
+    expect(screen.getByTestId('email-provider-EmailJS')).toBeInTheDocument();
+    expect(screen.getByText('Priority 1')).toBeInTheDocument();
+    expect(screen.getByText('Priority 2')).toBeInTheDocument();
+  });
+
+  it('shows Healthy/Unhealthy badges per provider', () => {
+    render(
+      <EmailProviderHealth
+        providers={providers}
+        rateLimitStatus={rateLimitStatus}
+      />
+    );
+    expect(screen.getByText('Healthy')).toBeInTheDocument();
+    expect(screen.getByText('Unhealthy')).toBeInTheDocument();
+  });
+
+  it('surfaces a provider lastError when present', () => {
+    render(
+      <EmailProviderHealth
+        providers={providers}
+        rateLimitStatus={rateLimitStatus}
+      />
+    );
+    expect(screen.getByText(/network timeout/i)).toBeInTheDocument();
+  });
+
+  it('renders the rate-limit remaining count and OK status', () => {
+    render(
+      <EmailProviderHealth
+        providers={providers}
+        rateLimitStatus={rateLimitStatus}
+      />
+    );
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('OK')).toBeInTheDocument();
+  });
+
+  it('shows a Rate limited badge when isLimited', () => {
+    render(
+      <EmailProviderHealth
+        providers={providers}
+        rateLimitStatus={{ ...rateLimitStatus, isLimited: true, remaining: 0 }}
+      />
+    );
+    expect(screen.getByText('Rate limited')).toBeInTheDocument();
+  });
+
+  it('shows an empty-state alert when no providers are configured', () => {
+    render(
+      <EmailProviderHealth providers={[]} rateLimitStatus={rateLimitStatus} />
+    );
+    expect(
+      screen.getByText(/no email providers configured/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/organisms/EmailProviderHealth/EmailProviderHealth.tsx
+++ b/src/components/organisms/EmailProviderHealth/EmailProviderHealth.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import React from 'react';
+import type { ProviderStatus } from '@/utils/email/types';
+
+/** Rate-limit snapshot from emailService.getRateLimitStatus(). */
+export interface EmailRateLimitStatus {
+  remaining: number;
+  resetTime: number;
+  isLimited: boolean;
+}
+
+export interface EmailProviderHealthProps {
+  /** Per-provider health from emailService.getStatus() */
+  providers: ProviderStatus[];
+  /** Rate-limit snapshot from emailService.getRateLimitStatus() */
+  rateLimitStatus: EmailRateLimitStatus | null;
+  /** Show loading skeleton */
+  isLoading?: boolean;
+  /** Additional CSS classes */
+  className?: string;
+  /** Test ID */
+  testId?: string;
+}
+
+function formatResetTime(resetTime: number): string {
+  return new Date(resetTime).toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+/**
+ * EmailProviderHealth — admin-facing health dashboard for the dual-provider
+ * email abstraction (#34). Renders one card per provider (priority, availability,
+ * failure count, healthy flag, last error) plus the current send rate-limit.
+ * Pure presentational; the page wires it to emailService.getStatus() /
+ * getRateLimitStatus().
+ *
+ * @category organisms
+ */
+export default function EmailProviderHealth({
+  providers,
+  rateLimitStatus,
+  isLoading = false,
+  className = '',
+  testId = 'email-provider-health',
+}: EmailProviderHealthProps) {
+  if (isLoading) {
+    return (
+      <div
+        className={`flex flex-col gap-4 ${className}`}
+        role="status"
+        aria-live="polite"
+        data-testid={testId}
+      >
+        <div className="skeleton h-24 w-full" />
+        <div className="skeleton h-40 w-full" />
+        <span className="sr-only">Loading email provider health…</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`flex flex-col gap-6 ${className}`} data-testid={testId}>
+      {/* Rate limit */}
+      <section aria-labelledby="email-rate-limit-heading">
+        <h2 id="email-rate-limit-heading" className="mb-3 text-xl font-bold">
+          Send Rate Limit
+        </h2>
+        {rateLimitStatus ? (
+          <div className="stats stats-vertical sm:stats-horizontal shadow">
+            <div className="stat">
+              <div className="stat-title">Remaining</div>
+              <div className="stat-value text-2xl">
+                {rateLimitStatus.remaining}
+              </div>
+            </div>
+            <div className="stat">
+              <div className="stat-title">Status</div>
+              <div className="stat-value text-2xl">
+                {rateLimitStatus.isLimited ? (
+                  <span className="badge badge-error badge-lg">
+                    Rate limited
+                  </span>
+                ) : (
+                  <span className="badge badge-success badge-lg">OK</span>
+                )}
+              </div>
+            </div>
+            <div className="stat">
+              <div className="stat-title">Window resets</div>
+              <div className="stat-value text-2xl">
+                {formatResetTime(rateLimitStatus.resetTime)}
+              </div>
+            </div>
+          </div>
+        ) : (
+          <p className="text-base-content/70">Rate-limit status unavailable.</p>
+        )}
+      </section>
+
+      {/* Providers */}
+      <section aria-labelledby="email-providers-heading">
+        <h2 id="email-providers-heading" className="mb-3 text-xl font-bold">
+          Providers
+        </h2>
+        {providers.length === 0 ? (
+          <div className="alert alert-warning" role="alert">
+            <span>No email providers configured.</span>
+          </div>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2">
+            {providers.map((p) => (
+              <div
+                key={p.name}
+                className="card bg-base-100 shadow-xl"
+                data-testid={`email-provider-${p.name}`}
+              >
+                <div className="card-body">
+                  <div className="flex items-start justify-between">
+                    <div>
+                      <h3 className="text-lg font-bold">{p.name}</h3>
+                      <p className="text-base-content/70 text-sm">
+                        Priority {p.priority}
+                      </p>
+                    </div>
+                    {p.healthy ? (
+                      <span className="badge badge-success">Healthy</span>
+                    ) : (
+                      <span className="badge badge-error">Unhealthy</span>
+                    )}
+                  </div>
+
+                  <div className="mt-3 space-y-1 border-t pt-3 text-sm">
+                    <div className="flex justify-between">
+                      <span className="font-semibold">Available</span>
+                      <span>{p.available ? 'Yes' : 'No'}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="font-semibold">Recent failures</span>
+                      <span>{p.failures}</span>
+                    </div>
+                    {p.lastError && (
+                      <div
+                        className="alert alert-error mt-2 p-2 text-xs"
+                        role="alert"
+                      >
+                        <span>Last error: {p.lastError}</span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/components/organisms/EmailProviderHealth/index.tsx
+++ b/src/components/organisms/EmailProviderHealth/index.tsx
@@ -1,0 +1,5 @@
+export { default, default as EmailProviderHealth } from './EmailProviderHealth';
+export type {
+  EmailProviderHealthProps,
+  EmailRateLimitStatus,
+} from './EmailProviderHealth';


### PR DESCRIPTION
Closes #34.

## What
Adds the admin-facing provider health dashboard for the dual-provider email abstraction (the optional gap from #34 — failover already works transparently).

- **`/admin/email`** route under the existing admin `ProtectedRoute → AdminGate` layout, mirroring `admin/payments`. Wires `emailService.getStatus()` / `getRateLimitStatus()` to the organism.
- **`EmailProviderHealth`** organism (5-file pattern) — per-provider cards (priority, availability, recent failures, healthy flag, last error) + the current send rate-limit (remaining / OK-vs-limited / window reset). Mirrors `AdminPaymentPanel`'s shape.
- Adds an **Email** tab to the admin nav.

## Verification
- `pnpm run type-check`, `pnpm run lint`, `pnpm run validate:structure` (109/109) green.
- 10 tests pass (7 unit + 3 a11y, zero axe violations).
- `pnpm build` exports `/admin/email`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)