### PR TITLE
fix(messaging): #30 iOS safe-area input + Deleted-vs-Unknown user (completes all 5)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -60,6 +60,11 @@ export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
   maximumScale: 5,
+  // viewport-fit=cover lets the app draw into the iOS safe-area insets and makes
+  // env(safe-area-inset-*) non-zero, so safe-area padding (e.g. the messaging
+  // input row, #30 fix #1) actually clears the home indicator. Without this,
+  // env() resolves to 0 and the padding is a no-op.
+  viewportFit: 'cover',
   themeColor: [
     { media: '(prefers-color-scheme: light)', color: '#f5f0eb' },
     { media: '(prefers-color-scheme: dark)', color: '#1a1a2e' },

--- a/src/app/messages/page.tsx
+++ b/src/app/messages/page.tsx
@@ -75,7 +75,7 @@ function MessagesLayout() {
         <SearchParamsReader onParams={handleParams} />
       </Suspense>
 
-      <div className="bg-base-100 fixed inset-x-0 top-16 bottom-28 overflow-hidden">
+      <div className="bg-base-100 fixed inset-x-0 top-16 bottom-[calc(7rem+env(safe-area-inset-bottom))] overflow-hidden">
         <div className="drawer md:drawer-open h-full">
           <input
             id="sidebar-drawer"

--- a/src/components/organisms/ChatWindow/ChatWindow.tsx
+++ b/src/components/organisms/ChatWindow/ChatWindow.tsx
@@ -187,8 +187,10 @@ export default function ChatWindow({
         />
       </div>
 
-      {/* Row 3: Message Input (auto height) */}
-      <div className="border-base-300 bg-base-100 border-t px-4 pt-4 pb-6">
+      {/* Row 3: Message Input (auto height). pb keeps the 1.5rem base but
+          extends past the iOS home indicator via the safe-area inset (#30
+          fix #1; needs viewport-fit=cover, set in the root layout). */}
+      <div className="border-base-300 bg-base-100 border-t px-4 pt-4 pb-[max(1.5rem,env(safe-area-inset-bottom))]">
         <MessageInput
           onSend={onSendMessage}
           disabled={isBlocked}

--- a/src/components/organisms/ConversationView/ConversationView.test.tsx
+++ b/src/components/organisms/ConversationView/ConversationView.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
-import ConversationView from './ConversationView';
+import ConversationView, { resolveParticipantName } from './ConversationView';
 
 // ConversationView is a state-owning wrapper around ChatWindow. We mock
 // the service layer and the ChatWindow organism so tests assert wiring,
@@ -147,5 +147,30 @@ describe('ConversationView', () => {
       hiddenSpy.mockRestore();
       vi.useRealTimers();
     }
+  });
+});
+
+describe('resolveParticipantName (#30 fix #5)', () => {
+  it('returns Unknown User on a query error (transient — do not mislabel)', () => {
+    expect(resolveParticipantName(null, true)).toBe('Unknown User');
+    expect(resolveParticipantName({ display_name: 'Ada' }, true)).toBe(
+      'Unknown User'
+    );
+  });
+
+  it('returns Deleted User when the profile row is null (no error)', () => {
+    expect(resolveParticipantName(null, false)).toBe('Deleted User');
+  });
+
+  it('prefers display_name, then username, for a present profile', () => {
+    expect(
+      resolveParticipantName({ display_name: 'Ada', username: 'ada99' }, false)
+    ).toBe('Ada');
+    expect(
+      resolveParticipantName({ display_name: null, username: 'ada99' }, false)
+    ).toBe('ada99');
+    expect(
+      resolveParticipantName({ display_name: '', username: '' }, false)
+    ).toBe('Unknown User');
   });
 });

--- a/src/components/organisms/ConversationView/ConversationView.tsx
+++ b/src/components/organisms/ConversationView/ConversationView.tsx
@@ -13,6 +13,22 @@ import type { DecryptedMessage } from '@/types/messaging';
 
 const logger = createLogger('organisms:ConversationView');
 
+/**
+ * Resolve the display name for the other 1-to-1 participant, distinguishing
+ * three cases (#30 fix #5):
+ *  - query failed (transient/RLS) → 'Unknown User' (neutral; don't mislabel)
+ *  - no profile row (null)        → 'Deleted User' (account genuinely gone)
+ *  - profile present              → display_name || username || 'Unknown User'
+ */
+export function resolveParticipantName(
+  profile: { username?: string | null; display_name?: string | null } | null,
+  hadError: boolean
+): string {
+  if (hadError) return 'Unknown User';
+  if (!profile) return 'Deleted User';
+  return profile.display_name || profile.username || 'Unknown User';
+}
+
 export interface ConversationViewProps {
   /** Conversation to display. The component owns all message state internally;
    *  changing this prop resets and reloads. */
@@ -121,13 +137,10 @@ export default function ConversationView({
 
       if (profileError) {
         logger.warn('Profile query error', { error: profileError.message });
-        setParticipantName('Unknown User');
-        return;
       }
-
-      setParticipantName(
-        profile?.display_name || profile?.username || 'Unknown User'
-      );
+      // Distinguish deleted account (null row) from a transient query error and
+      // from a present-but-unnamed profile (#30 fix #5).
+      setParticipantName(resolveParticipantName(profile, !!profileError));
     } catch (err) {
       logger.warn('Error loading participant info', { error: err });
       setParticipantName('Unknown User');


### PR DESCRIPTION
Closes #30.

This ships the last 2 of #30's 5 fixes; the other 3 already shipped (verified on main), so #30 is now complete:
- Fix #2 (full-page messaging setup) ✓ `src/app/messages/setup/page.tsx`
- Fix #3 (password-manager hints) ✓ `new-password` autocomplete + save-password prompt in setup
- Fix #4 (encrypted-with-previous-keys indicator) ✓ `MessageBubble.tsx:249`

## This PR
- **Fix #1 (iOS Safari input hidden behind the home indicator):** root cause was a missing `viewport-fit=cover`, leaving `env(safe-area-inset-*)` at 0. Add `viewportFit:'cover'` to the root viewport, then extend the message-input padding (`pb → max(1.5rem, env(safe-area-inset-bottom))`) and the fixed `/messages` container bottom inset so the input clears the indicator.
- **Fix #5 (deleted vs unknown user):** `ConversationView` now distinguishes a genuinely missing profile row (`maybeSingle → null` = "Deleted User") from a transient query error (neutral "Unknown User") and a present-but-unnamed profile (`display_name || username` fallback). Extracted as a pure `resolveParticipantName` helper + unit-tested. `ConversationListItem` is intentionally unchanged — its `participant?` prop can't distinguish null (deleted) from undefined (not-loaded), so forcing "Deleted User" there would mislabel loading states.

## Verification
- type-check / lint / build green; 3 new `resolveParticipantName` tests (error→Unknown, null→Deleted, present→fallback) + existing ConversationView suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)